### PR TITLE
Add system stats and icon management

### DIFF
--- a/start-desktop.sh
+++ b/start-desktop.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python -m webbrowser http://localhost:8000

--- a/start-flask.sh
+++ b/start-flask.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export FLASK_APP=DRIVE/app.py
+export FLASK_ENV=development
+flask run --host=0.0.0.0 --port=8000


### PR DESCRIPTION
## Summary
- Display CPU/RAM usage and open windows in System Processes window with backend `/api/system-stats`
- Provide icon selection for apps via new `/api/list-icons` endpoint and Settings panel dropdown
- Introduce Crypto Portfolio app, Flask startup scripts, and improved Chat with image support
- Remove binary crypto icon and reuse existing icon to enable PR creation

## Testing
- ✅ `python -m py_compile DRIVE/app.py`
- ✅ `node --check main.js`
- ⚠️ `pip install flake8` *(ProxyError: Tunnel connection failed: 403 Forbidden)*
- ⚠️ `flake8 DRIVE/app.py` *(command not found)*
- ⚠️ `npx eslint main.js` *(couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68b139cf16708330889e4ba59d1d0ef9