### PR TITLE
Add one-click install and startup scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 __pycache__/
 *.pyc
+
+.venv/

--- a/README.md
+++ b/README.md
@@ -47,61 +47,23 @@ The desktop uses the [File System Access API](https://developer.chrome.com/docs/
 
 ## Installation
 
+### Prerequisites
+
+* [Python 3](https://www.python.org/) with the `venv` module and `pip`.
+
 ### Windows
 
 1. Download the release ZIP archive and extract its contents into a folder of your choice, e.g. `C:\\Win95Desktop`.
-2. Open a terminal (PowerShell or Command Prompt) and navigate into the extracted folder.
-3. Start a local server.  Serving the files over `http://localhost` is necessary for the File System Access API to work – opening the HTML file directly via `file://` disables many features【889520036319150†L185-L193】.
-
-   *To use the Flask backend (recommended):*  Ensure you have Python and the dependencies `flask` and `pillow` installed.  Open a terminal, navigate to the extracted folder and run:
-
-   ```powershell
-   python DRIVE\app.py
-   ```
-
-   This will start the API server on port 8000 and serve the front‑end assets.  All API endpoints (e.g. `/api/status`, `/api/run-script`) will be available.
-
-   *To use the simple static server:*  If you prefer not to install Flask or Pillow, a convenient batch file, `start_server.bat`, is included; double‑click it in Explorer to launch a basic HTTP server:
-
-   ```powershell
-   start_server.bat
-   ```
-
-   Alternatively, open a terminal and run:
-
-   ```powershell
-   python -m http.server 8000
-   ```
-
-4. Open your browser (Chrome or Edge) and navigate to `http://localhost:8000/index.html`.  The desktop will load and you can begin using the applications.
+2. (Optional) Double‑click `install.bat` to create a `.venv` and install Flask, Pillow and psutil.
+3. Launch the backend with `start_server.bat`.  The script activates the virtual environment if it exists and starts the app on port 8000.
+4. Open your browser (Chrome or Edge) and navigate to `http://localhost:8000/index.html` to use the desktop.
 
 ### Linux
 
 1. Download and extract the ZIP archive into a directory, for example `~/win95-desktop`.
-2. Open a terminal and change into that directory.
-3. Start a local server.  Serving the files over `http://localhost` is necessary for the File System Access API to work – opening the HTML file directly via `file://` disables many features【889520036319150†L185-L193】.
-
-   *To use the Flask backend (recommended):*  Ensure Python, Flask and Pillow are installed.  Run the backend with:
-
-   ```bash
-   python DRIVE/app.py
-   ```
-
-   This starts the API server on port 8000 and also serves the static assets.
-
-   *To use the simple static server:*  A helper script, `start_server.sh`, is provided to launch Python’s built‑in HTTP server:
-
-   ```bash
-   ./start_server.sh
-   ```
-
-   You can also manually run:
-
-   ```bash
-   python3 -m http.server 8000
-   ```
-
-4. Open a Chromium‑based browser and visit `http://localhost:8000/index.html` to use the desktop environment.
+2. (Optional) Run `./install.sh` to create a `.venv` and install Flask, Pillow and psutil.
+3. Start the server with `./start_server.sh`, which activates the virtual environment if present and launches the app on port 8000.
+4. Open a Chromium‑based browser and visit `http://localhost:8000/index.html`.
 
 ### Running directly from the file system
 

--- a/install.bat
+++ b/install.bat
@@ -1,0 +1,6 @@
+@echo off
+python -m venv .venv
+call .venv\Scripts\activate
+pip install --upgrade pip
+pip install Flask Pillow psutil
+echo Installed Flask/Pillow/psutil.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install Flask Pillow psutil
+echo "Installed Flask/Pillow/psutil."

--- a/start_server.bat
+++ b/start_server.bat
@@ -1,14 +1,3 @@
 @echo off
-REM
-REM start_server.bat – Simple launcher script for the Win95‑style browser desktop
-REM
-REM This batch file starts a local HTTP server so that the File System Access API
-REM functions correctly.  It requires Python to be installed and available in
-REM the PATH.  The server listens on port 8000 by default.
-
-cd /d %~dp0
-echo Starting local HTTP server on http://localhost:8000 ...
-echo Press Ctrl+C to stop.
-
-python -m http.server 8000
-pause
+call .venv\Scripts\activate 2>nul
+python DRIVE\app.py

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,15 +1,4 @@
-#!/bin/bash
-#
-# start_server.sh – Simple launcher script for the Win95‑style browser desktop
-#
-# This script starts a local HTTP server so that the File System Access API
-# functions correctly.  It requires Python 3 to be installed.  The server
-# listens on port 8000 by default.
-
-DIR="$(cd "$(dirname "$0")" && pwd)"
-cd "$DIR"
-
-echo "Starting local HTTP server on http://localhost:8000 ..."
-echo "Press Ctrl+C to stop."
-
-python3 -m http.server 8000
+#!/usr/bin/env bash
+set -e
+source .venv/bin/activate 2>/dev/null || true
+python3 DRIVE/app.py


### PR DESCRIPTION
## Summary
- add install scripts for Windows and Linux to set up a virtual environment
- simplify server launch scripts to run `DRIVE/app.py` from optional `.venv`
- document one-click setup in README and ignore generated `.venv`

## Testing
- `bash install.sh` *(fails: Could not find a version that satisfies the requirement Flask)*
- `./start_server.sh` *(fails: Could not find a version that satisfies the requirement Flask)*

------
https://chatgpt.com/codex/tasks/task_e_68b1840e1dac83308cabc0ef74e2e536