### PR TITLE
feat: improve file manager CRUD and base path

### DIFF
--- a/DRIVE/app.py
+++ b/DRIVE/app.py
@@ -263,8 +263,9 @@ def upload_icon():
 # Base directory that the file manager is allowed to access.  Paths provided
 # by the client are interpreted relative to this directory.  The resolved path
 # is always checked to ensure it does not escape this directory to mitigate
-# directory traversal attacks.
-FILE_BASE = BASE_DIR
+# directory traversal attacks.  The base directory can be overridden with the
+# FILE_BASE environment variable for flexibility.
+FILE_BASE = Path(os.environ.get("FILE_BASE", BASE_DIR)).resolve()
 
 
 def _safe_path(rel_path: str) -> Path:


### PR DESCRIPTION
## Summary
- allow configuring file manager base directory via `FILE_BASE` environment variable
- add reusable file-manager actions and expose them through a context menu for new folder, upload, rename and delete

## Testing
- `python -m py_compile DRIVE/app.py`
- `npx eslint main.js` *(failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b18df4407883308f9214dbde3383a4