### PR TITLE
fix: Pillow pin for Python 3.13 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ A Windows 95 inspired desktop environment that runs entirely in the browser. A l
 
 ## Installation
 
+On Python 3.13+, Pillow>=11 is required. The requirements file handles this automatically.
+
 Run the bundled start script. It will create a virtual environment,
 install dependencies and launch the server.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Flask==3.0.2
-Pillow==10.2.0
+Pillow==10.2.0 ; python_version < "3.13"
+Pillow>=11.0.0,<12 ; python_version >= "3.13"
 psutil==5.9.8
 python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- add environment markers for Pillow so Python 3.13+ pulls Pillow 11 while older Pythons continue to use 10.2.0
- document Pillow 11 requirement for Python 3.13 in the installation section

## Testing
- Windows: `py -m venv .venv && .venv\Scripts\python -m pip install -U pip && .venv\Scripts\pip install -r requirements.txt --only-binary=:all:`
- Linux/macOS: `python -m venv .venv && . .venv/bin/activate && pip install -U pip && pip install -r requirements.txt --only-binary=:all:`
- `python -c "import PIL, flask; print(PIL.__version__)"`


------
https://chatgpt.com/codex/tasks/task_e_68b2b63f79108330911f4dd917f32e13