### PR TITLE
Fix server startup by ensuring tools package is discoverable

### DIFF
--- a/DRIVE/__init__.py
+++ b/DRIVE/__init__.py
@@ -1,0 +1,1 @@
+"""DRIVE package for ErikOS server."""

--- a/scripts/start.py
+++ b/scripts/start.py
@@ -72,13 +72,19 @@ def find_free_port(start: int = 8000) -> int:
 def start_backend(python: Path, port: int) -> subprocess.Popen[str]:
     env = os.environ.copy()
     env["FLASK_RUN_PORT"] = str(port)
-    cmd = [str(python), str(DRIVE_APP)]
+    # Ensure the project root is on PYTHONPATH so local packages like
+    # ``tools`` can be imported when the server starts.  Using ``-m`` also
+    # runs the application as a module, which makes relative imports more
+    # reliable across platforms.
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    cmd = [str(python), "-m", "DRIVE.app"]
     return subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
         env=env,
+        cwd=REPO_ROOT,
     )
 
 

--- a/start_server_debug.bat
+++ b/start_server_debug.bat
@@ -23,8 +23,9 @@ for m in ("flask","PIL","psutil"):
         print("[FAIL] import", m, e)
 PY
 
-echo [RUN] Starting DRIVE\app.py ... >> "%DLOG%"
-"%PY_EXE%" DRIVE\app.py >> "%DLOG%" 2>&1
+echo [RUN] Starting DRIVE.app ... >> "%DLOG%"
+set PYTHONPATH=%CD%
+"%PY_EXE%" -m DRIVE.app >> "%DLOG%" 2>&1
 echo [EXIT %ERRORLEVEL%] >> "%DLOG%"
 echo See "%DLOG%" for details.
 pause

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Utility tools for ErikOS server."""


### PR DESCRIPTION
## Summary
- ensure backend launch sets PYTHONPATH and runs `DRIVE.app` as a module
- add package markers for `tools` and `DRIVE`
- adjust debug launcher to honour PYTHONPATH

## Testing
- `python -m py_compile ErikOS/scripts/start.py ErikOS/tools/__init__.py ErikOS/DRIVE/__init__.py`
- `timeout 10 python ErikOS/scripts/start.py --port 8123` *(fails: Cannot connect to proxy. 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b79482f0833080b0f724d8069989