### PR TITLE
fix(server): use package-relative imports and correct routes; update FLASK_APP

### DIFF
--- a/DRIVE/app.py
+++ b/DRIVE/app.py
@@ -34,8 +34,8 @@ from logging.handlers import RotatingFileHandler
 from flask import Flask, jsonify, request, send_from_directory, g
 
 from tools.diagnostics import run_diagnostics
-from config import settings
-from __version__ import __version__
+from .config import settings
+from .__version__ import __version__
 
 BASE_DIR = settings.root_dir
 STATIC_DIR = BASE_DIR
@@ -247,7 +247,7 @@ def list_ollama_models():
     return jsonify(resp)
 
 
-@app.route("/api/ollama/history/<profile>")
+@app.get("/api/ollama/history/<profile>")
 def get_chat_history(profile: str):
     """Return stored chat history for the given profile."""
     profile = _safe_profile_name(profile)
@@ -336,6 +336,8 @@ def serve_static(filename: str):
     above.  If the file does not exist a 404 will be returned.
     """
     return send_from_directory(STATIC_DIR, filename)
+
+
 @app.route("/api/status")
 def status() -> "Response":
     """Return health information for readiness checks."""

--- a/start-flask.sh
+++ b/start-flask.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-export FLASK_APP=DRIVE/app.py
+export FLASK_APP=DRIVE.app
 export FLASK_ENV=development
 flask run --host=0.0.0.0 --port=8000


### PR DESCRIPTION
## Summary
- use package-relative imports in the Flask app
- fix history endpoint signature and static file route
- start Flask with package path

## Testing
- `python -m py_compile DRIVE/app.py`
- `pip install -r requirements.txt --only-binary=:all:` *(fails: Could not find a version that satisfies the requirement Flask==3.0.2)*
- `python -m DRIVE.app` *(fails: ModuleNotFoundError: No module named 'flask')*
- `curl http://127.0.0.1:8000/api/status` *(fails: Couldn't connect to server)*

## Validation
### Windows
```sh
py -m venv .venv
.venv\Scripts\python -m pip install -U pip
.venv\Scripts\pip install -r requirements.txt --only-binary=:all:
.venv\Scripts\python -m DRIVE.app
curl http://127.0.0.1:8000/api/status
```

### Linux/macOS
```sh
python3 -m venv .venv
. .venv/bin/activate
pip install -U pip
pip install -r requirements.txt --only-binary=:all:
python -m DRIVE.app
curl http://127.0.0.1:8000/api/status
```

------
https://chatgpt.com/codex/tasks/task_e_68b2bb3a21c48330a158a52b142722f3