### PR TITLE
Improve path traversal checks

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -40,6 +40,14 @@ def test_file_manager_invalid_paths(client):
     assert resp.status_code == 400
 
 
+def test_windows_style_traversal_blocked(client):
+    """Backslashes should be treated as path separators and rejected."""
+    resp = client.get("/api/list-directory", query_string={"path": "..\\"})
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data.get("error") == "Invalid path"
+
+
 def test_diagnostics_missing_icon():
     main_js = Path("main.js")
     original = main_js.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Normalize path separators and restrict absolute/drive paths in safe_join
- Add regression test ensuring Windows-style backslashes are rejected

## Testing
- `pytest tests/test_api.py::test_windows_style_traversal_blocked -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4013090b483309082a1e26662ebe3