### PR TITLE
Improve install script and local server startup

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -62,5 +62,7 @@ if errorlevel 1 (
   exit /b 1
 )
 
-echo Install complete. Now run start_server.bat
+echo Installation successful. You may now run start_server.bat
+echo Press any key to exit.
+pause >nul
 exit /b 0

--- a/install.sh
+++ b/install.sh
@@ -81,3 +81,7 @@ then
 fi
 
 echo "Install complete. Now run start_server.sh"
+if [ -t 1 ]; then
+  read -n 1 -s -r -p "Press any key to exit..."
+  echo
+fi

--- a/start_server.bat
+++ b/start_server.bat
@@ -19,9 +19,9 @@ echo Starting ErikOS server on port %PORT% ...
 REM Launch server in a new window so this script can continue
 start "ErikOS Server" cmd /c ".venv\Scripts\python -m DRIVE.app"
 
-REM Wait up to 20 seconds for the port to respond
+REM Wait up to 20 seconds for the port to respond using a simple TCP check
 powershell -NoProfile -Command ^
-  "$p=%PORT%;$ok=$false;for($i=0;$i -lt 20;$i++){if((Test-NetConnection 127.0.0.1 -Port $p -WarningAction SilentlyContinue).TcpTestSucceeded){$ok=$true;break};Start-Sleep -Seconds 1}; if(-not $ok){exit 1}"
+  "$p=%PORT%;$limit=(Get-Date).AddSeconds(20);while((Get-Date) -lt $limit){try{(New-Object System.Net.Sockets.TcpClient).Connect('127.0.0.1',$p);exit 0}catch{Start-Sleep -Milliseconds 500}};exit 1"
 
 if errorlevel 1 (
   echo Server did not become ready on port %PORT%.


### PR DESCRIPTION
## Summary
- keep Windows install window open with a success prompt
- add optional key prompt for install.sh when run interactively
- switch Windows start script to a simple TCP check for local server readiness

## Testing
- ⚠️ `./install.sh` (dependency installation blocked: Could not find Flask==3.0.2)
- ✅ `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b43bf73b388330be4257343868e010