### PR TITLE
Fix Windows install and start scripts

### DIFF
--- a/start_server.bat
+++ b/start_server.bat
@@ -1,23 +1,26 @@
 @echo off
 setlocal ENABLEEXTENSIONS
 cd /d "%~dp0"
+set "EXITCODE=0"
 
 if not exist ".venv\Scripts\python.exe" (
   echo Missing virtual environment. Run install.bat first.
-  exit /b 1
+  set "EXITCODE=1"
+  goto end
 )
 
 call ".venv\Scripts\activate"
 if errorlevel 1 (
   echo Error: could not activate .venv
-  exit /b 1
+  set "EXITCODE=1"
+  goto end
 )
 
 if "%PORT%"=="" set "PORT=8000"
 
 echo Starting ErikOS server on port %PORT% ...
 REM Launch server in a new window so this script can continue
-start "ErikOS Server" cmd /c ".venv\Scripts\python -m DRIVE.app"
+start "ErikOS Server" cmd /k ".venv\Scripts\python -m DRIVE.app & echo. & echo Press any key to close this window... & pause"
 
 REM Wait up to 20 seconds for the port to respond using a simple TCP check
 powershell -NoProfile -Command ^
@@ -26,9 +29,14 @@ powershell -NoProfile -Command ^
 if errorlevel 1 (
   echo Server did not become ready on port %PORT%.
   echo Check logs in the 'logs' folder or the new server window.
-  exit /b 1
+  set "EXITCODE=1"
+  goto end
 )
 
 start "" "http://127.0.0.1:%PORT%/index.html"
 echo Server started. A browser window should open shortly.
-exit /b 0
+
+:end
+echo Press any key to exit.
+pause >nul
+exit /b %EXITCODE%


### PR DESCRIPTION
## Summary
- Ensure install.bat pauses on errors and reports failure codes
- Keep start_server.bat windows open and report start failures

## Testing
- `./install.sh` *(fails: Could not find a version that satisfies the requirement Flask==3.0.2)*
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b43ecfd0b88330945861d48f796287