### PR TITLE
Handle invalid ROOT_DIR on Windows and set logs to working dir

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,6 @@
 HOST=127.0.0.1
 PORT=8000
 ALLOWED_ORIGINS=http://localhost:*
-ROOT_DIR=/workspace/ErikOS
 LOG_LEVEL=INFO
 TERMINAL_WHITELIST=ls,dir,echo,ping
 MAX_UPLOAD_MB=25

--- a/DRIVE/config.py
+++ b/DRIVE/config.py
@@ -23,6 +23,25 @@ def _split_csv(value: str) -> list[str]:
     return [item.strip() for item in value.split(",") if item.strip()]
 
 
+def _root_dir() -> Path:
+    """Determine a valid application root directory.
+
+    If ``ROOT_DIR`` is set in the environment use it when it points to an
+    existing path.  Otherwise fall back to the repository base directory.  This
+    avoids issues on Windows where an absolute path from another environment
+    may not exist.
+    """
+
+    candidate = Path(os.getenv("ROOT_DIR", BASE_DIR))
+    if not candidate.is_absolute():
+        candidate = (BASE_DIR / candidate).resolve()
+    else:
+        candidate = candidate.resolve()
+    if not candidate.exists():
+        candidate = BASE_DIR
+    return candidate
+
+
 @dataclass
 class Settings:
     host: str = os.getenv("HOST", "127.0.0.1")
@@ -35,7 +54,7 @@ class Settings:
             )
         )
     )
-    root_dir: Path = Path(os.getenv("ROOT_DIR", BASE_DIR)).resolve()
+    root_dir: Path = field(default_factory=_root_dir)
     log_level: str = os.getenv("LOG_LEVEL", "INFO")
     terminal_whitelist: list[str] = field(
         default_factory=lambda: _split_csv(

--- a/start_server.bat
+++ b/start_server.bat
@@ -1,6 +1,7 @@
 @echo off
 setlocal ENABLEEXTENSIONS
 cd /d "%~dp0"
+set "ROOT_DIR=%cd%"
 set "EXITCODE=0"
 
 if not exist ".venv\Scripts\python.exe" (


### PR DESCRIPTION
## Summary
- default to repository root if ROOT_DIR env var points to a non-existent path
- remove hard-coded ROOT_DIR from .env so logs stay within repo
- ensure Windows start script exports ROOT_DIR to current directory

## Testing
- `./install.sh` *(fails: Could not find a version that satisfies the requirement Flask==3.0.2)*
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b440f1d0a08330a176f293d17dc2cc