### PR TITLE
Add conversation history sidebar to chat window

### DIFF
--- a/style.css
+++ b/style.css
@@ -475,6 +475,24 @@ body {
   padding: 2px;
 }
 
+/* Conversation list items for chat */
+.chat-conversation-item {
+  padding: 6px;
+  margin: 2px;
+  border: 1px solid var(--window-border-dark);
+  cursor: pointer;
+}
+
+.chat-conversation-item:hover {
+  background: var(--selection-bg);
+  color: #fff;
+}
+
+.chat-conversation-item.active {
+  background: var(--selection-bg);
+  color: #fff;
+}
+
 /* Settings tabs styling */
 .settings-tabs {
   display: flex;


### PR DESCRIPTION
## Summary
- Split chat window into two-panel layout with conversation history sidebar and current chat area
- Track multiple conversations per user with new chat, selection and deletion
- Add CSS styles for conversation list items

## Testing
- `./run_tests.sh` *(fails: Virtual environment not found. Please run install.sh first.)*

------
https://chatgpt.com/codex/tasks/task_e_68b47a6eb32c8330a6761ef6cabef43b