### PR TITLE
feat: improve window management and scrolling

### DIFF
--- a/style.css
+++ b/style.css
@@ -413,9 +413,11 @@ body {
 .window .content {
   flex: 1;
   background: var(--window-bg);
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
   padding: 4px;
   font-size: 14px;
+  max-height: calc(100vh - 80px);
 }
 
 /* Desktop icons */
@@ -447,6 +449,8 @@ body {
 .chat-messages {
   font-family: var(--font-family);
   white-space: pre-wrap;
+  overflow-y: auto;
+  max-height: calc(100% - 40px);
 }
 
 .chat-message.user {
@@ -846,6 +850,7 @@ body {
   padding: 4px;
   overflow-y: auto;
   white-space: pre-wrap;
+  max-height: calc(100% - 40px);
 }
 
 .terminal-input {
@@ -908,6 +913,7 @@ body {
   overflow-y: auto;
   border-top: 1px solid var(--window-border-dark);
   padding: 4px;
+  max-height: calc(100% - 40px);
 }
 
 .file-item {
@@ -960,10 +966,13 @@ body {
   flex-direction: column;
   height: 100%;
   font-size: 14px;
+  min-width: 500px;
 }
 
 .settings-section {
   margin-bottom: 12px;
+  padding: 8px;
+  overflow-y: auto;
 }
 
 .settings-section h3 {


### PR DESCRIPTION
## Summary
- ensure new windows fit onscreen with sensible defaults and a maximize toggle
- constrain dragging to keep windows partially visible
- make window, chat, terminal, file manager, and settings content areas scrollable

## Testing
- `./run_tests.sh` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68b47d316af083308b18cd7b1d77cd37