### PR TITLE
Add chat settings and draggable grid icons

### DIFF
--- a/DRIVE/app.py
+++ b/DRIVE/app.py
@@ -695,7 +695,7 @@ def execute_command():
     return jsonify({"job_id": job_id})
 
 
-@app.route("/api/command-status/<job_id>")
+@app.get("/api/command-status/<job_id>")
 def command_status(job_id: str):
     job = command_jobs.get(job_id)
     if not job:

--- a/DRIVE/config.py
+++ b/DRIVE/config.py
@@ -58,7 +58,7 @@ class Settings:
     log_level: str = os.getenv("LOG_LEVEL", "INFO")
     terminal_whitelist: list[str] = field(
         default_factory=lambda: _split_csv(
-            os.getenv("TERMINAL_WHITELIST", "ls,dir,echo,ping")
+            os.getenv("TERMINAL_WHITELIST", "ls,dir,echo,ping,ollama")
         )
     )
     max_upload_mb: int = int(os.getenv("MAX_UPLOAD_MB", "25"))

--- a/style.css
+++ b/style.css
@@ -433,16 +433,13 @@ body {
 
 /* Grid layout styles for desktop icons */
 #desktop[data-layout="grid"] {
-  display: flex;
-  flex-wrap: wrap;
-  align-content: flex-start;
-  align-items: flex-start;
-  padding: 8px;
+  /* Absolute positioning allows drag snapping while preserving retro look */
+  position: relative;
 }
 
 #desktop[data-layout="grid"] .icon {
-  position: relative;
-  margin: 8px;
+  position: absolute;
+  margin: 0;
 }
 
 /* Chat application styles */


### PR DESCRIPTION
## Summary
- make taskbar buttons unpressed when windows are minimized
- add Chat settings with bubble colors and Ollama model management
- allow dragging desktop icons in grid mode with snapping

## Testing
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b5160ab360833090fe606836b7fb3e