### PR TITLE
feat: add draggable grid layout for icons

### DIFF
--- a/style.css
+++ b/style.css
@@ -431,15 +431,16 @@ body {
   user-select: none;
 }
 
-/* Grid layout styles for desktop icons */
+/* ERIKOS: Grid layout uses absolute positioning with padding for snapping */
 #desktop[data-layout="grid"] {
-  /* Absolute positioning allows drag snapping while preserving retro look */
   position: relative;
+  display: block; /* ERIKOS: stop flex-based flow so absolute positions work */
+  padding: 8px; /* ERIKOS: margin around grid */
 }
 
 #desktop[data-layout="grid"] .icon {
   position: absolute;
-  margin: 0;
+  margin: 0; /* ERIKOS: avoid extra drift */
 }
 
 /* Chat application styles */


### PR DESCRIPTION
## Summary
- allow grid mode desktop icons to be dragged with snapping and persistence
- switch grid layout to absolute positioning with padding for consistent snap points

## Testing
- ⚠️ `./install.sh` *(dependency install failed: could not fetch Flask)*
- ✅ `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b5196e2ef483308e082a77f868c6de