### PR TITLE
Sandbox per-user storage and limit profile count

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,13 @@ A Windows 95 inspired desktop environment that runs entirely in the browser. A l
 - **Sound Recorder**
 - **Volume** control
 - **Logs** viewer
-- **Profile Manager** for multiple users
+- **Profile Manager** for up to 5 users
+- **Per-user file storage** sandboxed under `DRIVE/users/<id>`
 - **Diagnostics** self-check tool
+
+## User data
+Each profile's files are isolated in `DRIVE/users/<id>` on the server.
+Profiles are limited to five to keep things tidy.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Scope file API paths to a per-user root under `DRIVE/users/<id>`
- Send current profile ID with file requests and cap profiles at five
- Document new per-user storage behavior

## Testing
- `./run_tests.sh` *(fails: Virtual environment not found. Please run install.sh first.)*

------
https://chatgpt.com/codex/tasks/task_e_68b5481077a48330866781e1ed9ecf30