### PR TITLE
Refactor module wiring and bootstrap desktop

### DIFF
--- a/DRIVE/app.py
+++ b/DRIVE/app.py
@@ -484,7 +484,7 @@ def _get_user_root() -> Path | None:
         data = request.get_json(silent=True) or {}
         uid = data.get("user")
     if not uid:
-        return None
+        uid = "guest"
     return user_root(uid)
 
 

--- a/js/apps/calculator.js
+++ b/js/apps/calculator.js
@@ -1,3 +1,5 @@
+import { openAppWindow } from '../utils/appWindow.js';
+
 export function openCalculator() {
-  console.warn('calculator app not implemented');
+  openAppWindow('calculator', 'Calculator');
 }

--- a/js/apps/calendar.js
+++ b/js/apps/calendar.js
@@ -1,3 +1,5 @@
+import { openAppWindow } from '../utils/appWindow.js';
+
 export function openCalendar() {
-  console.warn('calendar app not implemented');
+  openAppWindow('calendar', 'Calendar');
 }

--- a/js/apps/chat.js
+++ b/js/apps/chat.js
@@ -1,3 +1,5 @@
+import { openAppWindow } from '../utils/appWindow.js';
+
 export function openChat() {
-  console.warn('chat app not implemented');
+  openAppWindow('chat', 'Chat');
 }

--- a/js/apps/clock.js
+++ b/js/apps/clock.js
@@ -1,3 +1,5 @@
+import { openAppWindow } from '../utils/appWindow.js';
+
 export function openClock() {
-  console.warn('clock app not implemented');
+  openAppWindow('clock', 'Clock');
 }

--- a/js/apps/crypto.js
+++ b/js/apps/crypto.js
@@ -1,3 +1,5 @@
+import { openAppWindow } from '../utils/appWindow.js';
+
 export function openCrypto() {
-  console.warn('crypto app not implemented');
+  openAppWindow('crypto', 'Crypto Portfolio');
 }

--- a/js/apps/diagnostics.js
+++ b/js/apps/diagnostics.js
@@ -1,3 +1,5 @@
+import { openAppWindow } from '../utils/appWindow.js';
+
 export function openDiagnostics() {
-  console.warn('diagnostics app not implemented');
+  openAppWindow('diagnostics', 'Diagnostics');
 }

--- a/js/apps/fileManager.js
+++ b/js/apps/fileManager.js
@@ -1,3 +1,5 @@
+import { openAppWindow } from '../utils/appWindow.js';
+
 export function openFileManager() {
-  console.warn('file manager app not implemented');
+  openAppWindow('file-manager', 'File Manager');
 }

--- a/js/apps/gallery.js
+++ b/js/apps/gallery.js
@@ -1,3 +1,5 @@
+import { openAppWindow } from '../utils/appWindow.js';
+
 export function openGallery() {
-  console.warn('gallery app not implemented');
+  openAppWindow('gallery', 'Gallery');
 }

--- a/js/apps/linkManager.js
+++ b/js/apps/linkManager.js
@@ -1,3 +1,5 @@
+import { openAppWindow } from '../utils/appWindow.js';
+
 export function openLinkEditor() {
-  console.warn('link manager app not implemented');
+  openAppWindow('link-manager', 'Link Manager');
 }

--- a/js/apps/logs.js
+++ b/js/apps/logs.js
@@ -1,3 +1,5 @@
+import { openAppWindow } from '../utils/appWindow.js';
+
 export function openLogs() {
-  console.warn('logs app not implemented');
+  openAppWindow('logs', 'Logs');
 }

--- a/js/apps/mediaPlayer.js
+++ b/js/apps/mediaPlayer.js
@@ -1,3 +1,5 @@
+import { openAppWindow } from '../utils/appWindow.js';
+
 export function openMediaPlayer() {
-  console.warn('media player app not implemented');
+  openAppWindow('media-player', 'Media Player');
 }

--- a/js/apps/notepad.js
+++ b/js/apps/notepad.js
@@ -1,3 +1,5 @@
+import { openAppWindow } from '../utils/appWindow.js';
+
 export function openNotepad() {
-  console.warn('notepad app not implemented');
+  openAppWindow('notepad', 'Notepad');
 }

--- a/js/apps/paint.js
+++ b/js/apps/paint.js
@@ -1,3 +1,5 @@
+import { openAppWindow } from '../utils/appWindow.js';
+
 export function openPaint() {
-  console.warn('paint app not implemented');
+  openAppWindow('paint', 'Paint');
 }

--- a/js/apps/processes.js
+++ b/js/apps/processes.js
@@ -1,3 +1,5 @@
+import { openAppWindow } from '../utils/appWindow.js';
+
 export function openProcesses() {
-  console.warn('processes app not implemented');
+  openAppWindow('processes', 'System Processes');
 }

--- a/js/apps/profileManager.js
+++ b/js/apps/profileManager.js
@@ -1,3 +1,5 @@
+import { openAppWindow } from '../utils/appWindow.js';
+
 export function openProfileManager() {
-  console.warn('profile manager app not implemented');
+  openAppWindow('profiles', 'Profile Manager');
 }

--- a/js/apps/recorder.js
+++ b/js/apps/recorder.js
@@ -1,3 +1,5 @@
+import { openAppWindow } from '../utils/appWindow.js';
+
 export function openRecorder() {
-  console.warn('recorder app not implemented');
+  openAppWindow('recorder', 'Recorder');
 }

--- a/js/apps/settings.js
+++ b/js/apps/settings.js
@@ -1,3 +1,5 @@
+import { openAppWindow } from '../utils/appWindow.js';
+
 export function openSettings() {
-  console.warn('settings app not implemented');
+  openAppWindow('settings', 'Settings');
 }

--- a/js/apps/sheets.js
+++ b/js/apps/sheets.js
@@ -1,3 +1,5 @@
+import { openAppWindow } from '../utils/appWindow.js';
+
 export function openSheets() {
-  console.warn('sheets app not implemented');
+  openAppWindow('sheets', 'Sheets');
 }

--- a/js/apps/snip.js
+++ b/js/apps/snip.js
@@ -1,3 +1,5 @@
+import { openAppWindow } from '../utils/appWindow.js';
+
 export function openSnipTool() {
-  console.warn('snip tool app not implemented');
+  openAppWindow('snip', 'Snip');
 }

--- a/js/apps/terminal.js
+++ b/js/apps/terminal.js
@@ -1,3 +1,5 @@
+import { openAppWindow } from '../utils/appWindow.js';
+
 export function openTerminal() {
-  console.warn('terminal app not implemented');
+  openAppWindow('terminal', 'Terminal');
 }

--- a/js/apps/thermometer.js
+++ b/js/apps/thermometer.js
@@ -1,3 +1,5 @@
+import { openAppWindow } from '../utils/appWindow.js';
+
 export function openTempConverter() {
-  console.warn('thermometer app not implemented');
+  openAppWindow('thermometer', 'Temperature');
 }

--- a/js/apps/volume.js
+++ b/js/apps/volume.js
@@ -1,3 +1,5 @@
+import { openAppWindow } from '../utils/appWindow.js';
+
 export function openSoundAdjuster() {
-  console.warn('volume app not implemented');
+  openAppWindow('volume', 'Volume');
 }

--- a/js/apps/worldClock.js
+++ b/js/apps/worldClock.js
@@ -1,3 +1,5 @@
+import { openAppWindow } from '../utils/appWindow.js';
+
 export function openWorldClock() {
-  console.warn('world clock app not implemented');
+  openAppWindow('world-clock', 'World Clocks');
 }

--- a/js/bootstrap.js
+++ b/js/bootstrap.js
@@ -1,22 +1,37 @@
 // Entry point for ErikOS browser desktop.
 // Initialises globals and exposes them on window for legacy modules.
 
-import { applications, setCurrentUser } from './core/globals.js';
 import { windowManager } from './core/windowManager.js';
+import { initDesktop, teardownDesktop } from './core/desktop.js';
+import { registerTray, teardownTray } from './core/tray.js';
+import { applications, setCurrentUser } from './core/globals.js';
+
+function login() {
+  setCurrentUser({ id: 'guest', name: 'Guest' });
+  initDesktop();
+  registerTray();
+}
+
+export function logout() {
+  teardownDesktop();
+  teardownTray();
+  windowManager.clear();
+  setCurrentUser(null);
+  login();
+}
+
+export function bootstrap() {
+  login();
+}
+
+window.addEventListener('erikos-logout', logout);
 
 // Expose minimal APIs globally for existing inline handlers.
 window.ErikOS = {
   applications,
   windowManager,
   setCurrentUser,
+  logout,
 };
 
-// Basic login/bootstrap placeholder – real implementation would
-// display login screen and then render desktop/tray etc.
-export function bootstrap() {
-  // In the refactor this would handle user profiles and desktop init.
-  console.log('ErikOS bootstrapped with', applications.length, 'apps');
-}
-
-// Auto bootstrap when module is loaded.
 document.addEventListener('DOMContentLoaded', bootstrap);

--- a/js/core/desktop.js
+++ b/js/core/desktop.js
@@ -1,0 +1,67 @@
+import { applications } from './globals.js';
+
+let listeners = [];
+
+export function initDesktop() {
+  const startBtn = document.getElementById('start-button');
+  const startMenu = document.getElementById('start-menu');
+  const appList = document.getElementById('start-app-list');
+
+  appList.innerHTML = '';
+  applications.forEach(app => {
+    const li = document.createElement('li');
+    const btn = document.createElement('button');
+    btn.textContent = app.name;
+    btn.addEventListener('click', () => {
+      startMenu.setAttribute('aria-hidden', 'true');
+      app.launch();
+    });
+    li.appendChild(btn);
+    appList.appendChild(li);
+  });
+
+  const logoutLi = document.createElement('li');
+  const logoutBtn = document.createElement('button');
+  logoutBtn.id = 'start-logout-btn';
+  logoutBtn.textContent = 'Log Out';
+  logoutBtn.addEventListener('click', () => {
+    startMenu.setAttribute('aria-hidden', 'true');
+    window.dispatchEvent(new CustomEvent('erikos-logout'));
+  });
+  logoutLi.appendChild(logoutBtn);
+  appList.appendChild(logoutLi);
+
+  const toggleMenu = () => {
+    const hidden = startMenu.getAttribute('aria-hidden') === 'true';
+    startMenu.setAttribute('aria-hidden', hidden ? 'false' : 'true');
+  };
+  startBtn.addEventListener('click', toggleMenu);
+  listeners.push({ target: startBtn, type: 'click', handler: toggleMenu });
+
+  const outsideHandler = (e) => {
+    if (!startMenu.contains(e.target) && e.target !== startBtn) {
+      startMenu.setAttribute('aria-hidden', 'true');
+    }
+  };
+  window.addEventListener('pointerdown', outsideHandler);
+  listeners.push({ target: window, type: 'pointerdown', handler: outsideHandler });
+
+  const resizeHandler = () => {};
+  window.addEventListener('resize', resizeHandler);
+  listeners.push({ target: window, type: 'resize', handler: resizeHandler });
+
+  const keyHandler = (e) => {
+    if (e.key === 'Escape') startMenu.setAttribute('aria-hidden', 'true');
+  };
+  window.addEventListener('keydown', keyHandler);
+  listeners.push({ target: window, type: 'keydown', handler: keyHandler });
+}
+
+export function teardownDesktop() {
+  listeners.forEach(({ target, type, handler }) => target.removeEventListener(type, handler));
+  listeners = [];
+  const appList = document.getElementById('start-app-list');
+  if (appList) appList.innerHTML = '';
+  const startMenu = document.getElementById('start-menu');
+  if (startMenu) startMenu.setAttribute('aria-hidden', 'true');
+}

--- a/js/core/tray.js
+++ b/js/core/tray.js
@@ -1,0 +1,35 @@
+import { applications } from './globals.js';
+
+let listeners = [];
+
+function launch(id) {
+  const app = applications.find(a => a.id === id);
+  if (app) app.launch();
+}
+
+export function registerTray() {
+  const linksIcon = document.getElementById('tray-links-icon');
+  const snipIcon = document.getElementById('tray-snip-icon');
+  const volumeIcon = document.getElementById('tray-volume-icon');
+
+  if (linksIcon) {
+    const handler = () => launch('link-manager');
+    linksIcon.addEventListener('click', handler);
+    listeners.push({ target: linksIcon, type: 'click', handler });
+  }
+  if (snipIcon) {
+    const handler = () => launch('snip');
+    snipIcon.addEventListener('click', handler);
+    listeners.push({ target: snipIcon, type: 'click', handler });
+  }
+  if (volumeIcon) {
+    const handler = () => launch('volume');
+    volumeIcon.addEventListener('click', handler);
+    listeners.push({ target: volumeIcon, type: 'click', handler });
+  }
+}
+
+export function teardownTray() {
+  listeners.forEach(({ target, type, handler }) => target.removeEventListener(type, handler));
+  listeners = [];
+}

--- a/js/core/windowManager.js
+++ b/js/core/windowManager.js
@@ -15,8 +15,9 @@ class WindowManager {
     const win = document.createElement('div');
     win.classList.add('window');
     win.dataset.id = id;
-    win.style.left = '-9999px';
-    win.style.top = '-9999px';
+    const offset = (this.nextId - 2) * 30;
+    win.style.left = `${100 + offset}px`;
+    win.style.top = `${100 + offset}px`;
     win.style.zIndex = this.nextZ++;
 
     const titleBar = document.createElement('div');
@@ -29,6 +30,11 @@ class WindowManager {
       '</div>';
     win.appendChild(titleBar);
     win.appendChild(contentEl);
+
+    const [minBtn,, closeBtn] = titleBar.querySelectorAll('button');
+    minBtn.addEventListener('click', () => this.minimizeWindow(id));
+    closeBtn.addEventListener('click', () => this.closeWindow(id));
+    win.addEventListener('mousedown', () => this.focusWindow(id));
 
     this.desktop.appendChild(win);
     this.windows.set(id, win);
@@ -58,6 +64,8 @@ class WindowManager {
   minimizeWindow(id) {
     const win = this.windows.get(id);
     if (win) win.style.display = 'none';
+    const btn = this.taskbar.querySelector(`button[data-id="${id}"]`);
+    if (btn) btn.classList.remove('active');
   }
 
   restoreWindow(id) {
@@ -83,6 +91,15 @@ class WindowManager {
     } else {
       this.minimizeWindow(id);
     }
+  }
+
+  clear() {
+    this.windows.forEach((win, id) => {
+      win.remove();
+      const btn = this.taskbar.querySelector(`button[data-id="${id}"]`);
+      if (btn) btn.remove();
+    });
+    this.windows.clear();
   }
 }
 

--- a/js/utils/appWindow.js
+++ b/js/utils/appWindow.js
@@ -1,0 +1,7 @@
+import { windowManager } from '../core/windowManager.js';
+
+export function openAppWindow(id, title, message = `${title} app coming soon`) {
+  const content = document.createElement('div');
+  content.textContent = message;
+  windowManager.createWindow(id, title, content);
+}

--- a/js/utils/fsClient.js
+++ b/js/utils/fsClient.js
@@ -1,15 +1,34 @@
-// Simple wrapper around fetch to communicate with the ErikOS backend
-// adding the X-User-Id header and convenient JSON helpers.
+// Fetch helpers for ErikOS backend APIs.
+// Automatically includes X-User-Id header from currentUser.
 
-export async function apiFetch(url, options = {}) {
-  const opts = { ...options };
-  opts.headers = { 'X-User-Id': window.currentUserId || 'guest', ...(opts.headers || {}) };
-  const resp = await fetch(url, opts);
-  if (!resp.ok) throw new Error(`Request failed: ${resp.status}`);
-  return resp;
+import { currentUser } from '../core/globals.js';
+
+function userHeader() {
+  return { 'X-User-Id': currentUser ? currentUser.id : '' };
 }
 
-export async function apiJson(url, options = {}) {
-  const resp = await apiFetch(url, { ...options, headers: { 'Content-Type': 'application/json', ...(options.headers || {}) } });
+export async function getJSON(url) {
+  const resp = await fetch(url, { headers: userHeader() });
+  if (!resp.ok) throw new Error(`GET ${url} failed: ${resp.status}`);
+  return resp.json();
+}
+
+export async function postJSON(url, data) {
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...userHeader() },
+    body: JSON.stringify(data),
+  });
+  if (!resp.ok) throw new Error(`POST ${url} failed: ${resp.status}`);
+  return resp.json();
+}
+
+export async function uploadForm(url, formData) {
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: userHeader(),
+    body: formData,
+  });
+  if (!resp.ok) throw new Error(`POST ${url} failed: ${resp.status}`);
   return resp.json();
 }


### PR DESCRIPTION
## Summary
- Add desktop and tray modules to wire start menu, tray icons and logout handling
- Introduce shared window helper and update all app launchers to open placeholder windows
- Improve window manager and central fsClient utilities with user headers
- Default backend to guest user when no X-User-Id is provided

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b56c39292c833099eb353515d666a3