### PR TITLE
feat: render desktop icons from app registry

### DIFF
--- a/js/core/appRegistry.js
+++ b/js/core/appRegistry.js
@@ -1,0 +1,51 @@
+export async function loadApps() {
+  // Static array for now; could be replaced with fetch('/apps.json') etc.
+  const apps = [
+    { id: "notepad", name: "Notepad", icon: "./icons/notepad.png", launch: () => import('../apps/notepad.js').then(m => m.openNotepad()) },
+    { id: "file-manager", name: "File\u00A0Manager", icon: "./icons/file-manager.png", launch: () => import('../apps/fileManager.js').then(m => m.openFileManager()) },
+    { id: "terminal", name: "Terminal", icon: "./icons/terminal.png", launch: () => import('../apps/terminal.js').then(m => m.openTerminal()) },
+    { id: "settings", name: "Settings", icon: "./icons/settings.png", launch: () => import('../apps/settings.js').then(m => m.openSettings()) },
+    { id: "link-manager", name: "Link\u00A0Manager", icon: "./icons/link-manager.png", launch: () => import('../apps/linkManager.js').then(m => m.openLinkEditor()) },
+    { id: "processes", name: "System\u00A0Processes", icon: "./icons/processes.png", launch: () => import('../apps/processes.js').then(m => m.openProcesses()) },
+    { id: "media-player", name: "Media\u00A0Player", icon: "./icons/media-player.png", launch: () => import('../apps/mediaPlayer.js').then(m => m.openMediaPlayer()) },
+    { id: "clock", name: "Clock", icon: "./icons/clock.png", launch: () => import('../apps/clock.js').then(m => m.openClock()) },
+    { id: "calendar", name: "Calendar", icon: "./icons/calendar.png", launch: () => import('../apps/calendar.js').then(m => m.openCalendar()) },
+    { id: "world-clock", name: "World\u00A0Clocks", icon: "./icons/world-clock.png", launch: () => import('../apps/worldClock.js').then(m => m.openWorldClock()) },
+    { id: "calculator", name: "Calculator", icon: "./icons/calculator.png", launch: () => import('../apps/calculator.js').then(m => m.openCalculator()) },
+    { id: "paint", name: "Paint", icon: "./icons/paint.png", launch: () => import('../apps/paint.js').then(m => m.openPaint()) },
+    { id: "gallery", name: "Gallery", icon: "./icons/gallery.png", launch: () => import('../apps/gallery.js').then(m => m.openGallery()) },
+    { id: "thermometer", name: "Temperature", icon: "./icons/thermometer.png", launch: () => import('../apps/thermometer.js').then(m => m.openTempConverter()) },
+    { id: "recorder", name: "Recorder", icon: "./icons/recorder.png", launch: () => import('../apps/recorder.js').then(m => m.openRecorder()) },
+    { id: "volume", name: "Volume", icon: "./icons/media-player.png", launch: () => import('../apps/volume.js').then(m => m.openSoundAdjuster()) },
+    { id: "logs", name: "Logs", icon: "./icons/logs.png", launch: () => import('../apps/logs.js').then(m => m.openLogs()) },
+    { id: "profiles", name: "Profile\u00A0Manager", icon: "./icons/user.png", launch: () => import('../apps/profileManager.js').then(m => m.openProfileManager()) },
+    { id: "chat", name: "Chat", icon: "./icons/chat.png", launch: () => import('../apps/chat.js').then(m => m.openChat()) },
+    { id: "sheets", name: "Sheets", icon: "./icons/sheets.png", launch: () => import('../apps/sheets.js').then(m => m.openSheets()) },
+    { id: "crypto", name: "Crypto Portfolio", icon: "./icons/processes.png", launch: () => import('../apps/crypto.js').then(m => m.openCrypto()) },
+    { id: "diagnostics", name: "Diagnostics", icon: "./icons/settings-icon.png", launch: () => import('../apps/diagnostics.js').then(m => m.openDiagnostics()) },
+    { id: "snip", name: "Snip", icon: "./icons/gallery.png", launch: () => import('../apps/snip.js').then(m => m.openSnipTool()) }
+  ];
+
+  apps.forEach(app => {
+    if (app.icon) {
+      app.icon = app.icon.replace(/^\.\/?(?:public\/)?icons\//, '/icons/');
+    }
+  });
+  registry = apps;
+  return apps;
+}
+
+let registry = [];
+
+export function validateApps(apps) {
+  if (!Array.isArray(apps)) throw new Error('App registry must be an array');
+  apps.forEach(app => {
+    if (!app.id || !app.name || !app.icon || typeof app.launch !== 'function') {
+      throw new Error(`Invalid app definition for ${app && app.id}`);
+    }
+  });
+}
+
+export function getAppById(id) {
+  return registry.find(a => a.id === id);
+}

--- a/js/core/desktop.js
+++ b/js/core/desktop.js
@@ -1,21 +1,21 @@
-import { applications } from './globals.js';
+import { launchApp } from './launcher.js';
 
 let listeners = [];
 
-export function initDesktop() {
+export function initDesktop(apps = []) {
   const startBtn = document.getElementById('start-button');
   const startMenu = document.getElementById('start-menu');
   const appList = document.getElementById('start-app-list');
 
   console.time('BOOT: start');
   appList.innerHTML = '';
-  applications.forEach(app => {
+  apps.filter(a => a.startMenu !== false).forEach(app => {
     const li = document.createElement('li');
     const btn = document.createElement('button');
     btn.textContent = app.name;
     btn.addEventListener('click', () => {
       startMenu.setAttribute('aria-hidden', 'true');
-      app.launch();
+      launchApp(app.id);
     });
     li.appendChild(btn);
     appList.appendChild(li);
@@ -59,6 +59,22 @@ export function initDesktop() {
   console.timeEnd('BOOT: start');
 }
 
+export function renderDesktopIcons(apps) {
+  const root = document.getElementById('desktop');
+  if (!root) return;
+  root.innerHTML = '';
+  for (const app of apps.filter(a => a.desktop !== false)) {
+    const el = document.createElement('div');
+    el.className = 'icon';
+    el.dataset.appId = app.id;
+    el.innerHTML = `<img alt="${app.name}" loading="lazy"><span>${app.name}</span>`;
+    const img = el.querySelector('img');
+    img.src = app.icon || '/icons/default.png';
+    el.addEventListener('dblclick', () => launchApp(app.id));
+    root.appendChild(el);
+  }
+}
+
 export function teardownDesktop() {
   listeners.forEach(({ target, type, handler }) => target.removeEventListener(type, handler));
   listeners = [];
@@ -66,4 +82,6 @@ export function teardownDesktop() {
   if (appList) appList.innerHTML = '';
   const startMenu = document.getElementById('start-menu');
   if (startMenu) startMenu.setAttribute('aria-hidden', 'true');
+  const root = document.getElementById('desktop');
+  if (root) root.innerHTML = '';
 }

--- a/js/core/globals.js
+++ b/js/core/globals.js
@@ -1,42 +1,9 @@
-// Global state and application registry for ErikOS.
-// Profiles, current user, settings, and app definitions.
+// Global state for ErikOS.
+// Profiles, current user and settings are kept here.
 
 export const profiles = [];
 export let currentUser = null;
 export const settings = {};
-
-// Application registry used by the desktop and start menu.
-// Each entry defines an id, display name, icon and launch function.
-export const applications = [
-  { id: "notepad", name: "Notepad", icon: "./icons/notepad.png", launch: () => import('../apps/notepad.js').then(m => m.openNotepad()) },
-  { id: "file-manager", name: "File Manager", icon: "./icons/file-manager.png", launch: () => import('../apps/fileManager.js').then(m => m.openFileManager()) },
-  { id: "terminal", name: "Terminal", icon: "./icons/terminal.png", launch: () => import('../apps/terminal.js').then(m => m.openTerminal()) },
-  { id: "settings", name: "Settings", icon: "./icons/settings.png", launch: () => import('../apps/settings.js').then(m => m.openSettings()) },
-  { id: "link-manager", name: "Link Manager", icon: "./icons/link-manager.png", launch: () => import('../apps/linkManager.js').then(m => m.openLinkEditor()) },
-  { id: "processes", name: "System Processes", icon: "./icons/processes.png", launch: () => import('../apps/processes.js').then(m => m.openProcesses()) },
-  { id: "media-player", name: "Media Player", icon: "./icons/media-player.png", launch: () => import('../apps/mediaPlayer.js').then(m => m.openMediaPlayer()) },
-  { id: "clock", name: "Clock", icon: "./icons/clock.png", launch: () => import('../apps/clock.js').then(m => m.openClock()) },
-  { id: "calendar", name: "Calendar", icon: "./icons/calendar.png", launch: () => import('../apps/calendar.js').then(m => m.openCalendar()) },
-  { id: "world-clock", name: "World Clocks", icon: "./icons/world-clock.png", launch: () => import('../apps/worldClock.js').then(m => m.openWorldClock()) },
-  { id: "calculator", name: "Calculator", icon: "./icons/calculator.png", launch: () => import('../apps/calculator.js').then(m => m.openCalculator()) },
-  { id: "paint", name: "Paint", icon: "./icons/paint.png", launch: () => import('../apps/paint.js').then(m => m.openPaint()) },
-  { id: "gallery", name: "Gallery", icon: "./icons/gallery.png", launch: () => import('../apps/gallery.js').then(m => m.openGallery()) },
-  { id: "thermometer", name: "Temperature", icon: "./icons/thermometer.png", launch: () => import('../apps/thermometer.js').then(m => m.openTempConverter()) },
-  { id: "recorder", name: "Recorder", icon: "./icons/recorder.png", launch: () => import('../apps/recorder.js').then(m => m.openRecorder()) },
-  { id: "volume", name: "Volume", icon: "./icons/media-player.png", launch: () => import('../apps/volume.js').then(m => m.openSoundAdjuster()) },
-  { id: "logs", name: "Logs", icon: "./icons/logs.png", launch: () => import('../apps/logs.js').then(m => m.openLogs()) },
-  { id: "profiles", name: "Profile Manager", icon: "./icons/user.png", launch: () => import('../apps/profileManager.js').then(m => m.openProfileManager()) },
-  { id: "chat", name: "Chat", icon: "./icons/chat.png", launch: () => import('../apps/chat.js').then(m => m.openChat()) },
-  { id: "sheets", name: "Sheets", icon: "./icons/sheets.png", launch: () => import('../apps/sheets.js').then(m => m.openSheets()) },
-  { id: "crypto", name: "Crypto Portfolio", icon: "./icons/processes.png", launch: () => import('../apps/crypto.js').then(m => m.openCrypto()) },
-  { id: "diagnostics", name: "Diagnostics", icon: "./icons/settings-icon.png", launch: () => import('../apps/diagnostics.js').then(m => m.openDiagnostics()) },
-  { id: "snip", name: "Snip", icon: "./icons/gallery.png", launch: () => import('../apps/snip.js').then(m => m.openSnipTool()) }
-];
-
-// Helper to register an application dynamically.
-export function registerApp(app) {
-  applications.push(app);
-}
 
 export function setCurrentUser(user) {
   currentUser = user;

--- a/js/core/launcher.js
+++ b/js/core/launcher.js
@@ -1,0 +1,8 @@
+import { windowManager } from './windowManager.js';
+import { getAppById } from './appRegistry.js';
+
+export function launchApp(id) {
+  const app = getAppById(id);
+  if (!app) return;
+  windowManager.open(app);
+}

--- a/js/core/tray.js
+++ b/js/core/tray.js
@@ -1,10 +1,9 @@
-import { applications } from './globals.js';
+import { launchApp } from './launcher.js';
 
 let listeners = [];
 
 function launch(id) {
-  const app = applications.find(a => a.id === id);
-  if (app) app.launch();
+  launchApp(id);
 }
 
 export function registerTray() {

--- a/js/core/windowManager.js
+++ b/js/core/windowManager.js
@@ -10,6 +10,19 @@ class WindowManager {
     this.taskbar = document.getElementById('taskbar-windows');
   }
 
+  open(app) {
+    if (app && typeof app.launch === 'function' && !app.placeholder) {
+      try {
+        return app.launch();
+      } catch (e) {
+        console.error(e);
+      }
+    }
+    const content = document.createElement('div');
+    content.textContent = 'Coming Soon';
+    this.createWindow(app?.id || 'unknown', app?.name || 'App', content);
+  }
+
   createWindow(appId, title, contentEl) {
     const id = `${appId}-${this.nextId++}`;
     const win = document.createElement('div');


### PR DESCRIPTION
## Summary
- create centralized app registry with load and validation helpers
- add launcher and window manager integration for app opening
- render desktop icons and start menu entries from registry during bootstrap

## Testing
- `./run_tests.sh` *(fails: Virtual environment not found. Please run install.sh first.)*


------
https://chatgpt.com/codex/tasks/task_e_68b594302f4c8330af6098d2672f5dea