### PR TITLE
feat(desktop): render icons from registry

### DIFF
--- a/js/core/windowManager.js
+++ b/js/core/windowManager.js
@@ -11,16 +11,13 @@ class WindowManager {
   }
 
   open(app) {
-    if (app && typeof app.launch === 'function' && !app.placeholder) {
+    if (app && typeof app.launch === 'function') {
       try {
         return app.launch();
       } catch (e) {
         console.error(e);
       }
     }
-    const content = document.createElement('div');
-    content.textContent = 'Coming Soon';
-    this.createWindow(app?.id || 'unknown', app?.name || 'App', content);
   }
 
   createWindow(appId, title, contentEl) {

--- a/src/js/core/appRegistry.js
+++ b/src/js/core/appRegistry.js
@@ -1,0 +1,3 @@
+import { apps } from "../apps/index.js";
+export function loadApps() { return apps; }
+export function getAppById(id){ return apps.find(a=>a.meta.id===id); }

--- a/src/js/core/desktop.js
+++ b/src/js/core/desktop.js
@@ -1,0 +1,14 @@
+import { getAppById, loadApps } from "./appRegistry.js";
+export async function renderDesktopIcons(launcher){
+  const root = document.getElementById("desktop"); if (!root) return;
+  root.innerHTML = "";
+  for (const a of loadApps()){
+    const el = document.createElement("div");
+    el.className = "icon"; el.dataset.appId = a.meta.id;
+    el.innerHTML = `<img alt=""><span></span>`;
+    el.querySelector("img").src = a.meta.icon || "/icons/default.png";
+    el.querySelector("span").textContent = a.meta.name;
+    el.addEventListener("dblclick", ()=> launcher.launch(a.meta.id));
+    root.appendChild(el);
+  }
+}


### PR DESCRIPTION
## Summary
- centralize app registry and desktop rendering
- drop global "Coming Soon" fallback

## Testing
- `pytest -q`
- `npx eslint js/core/windowManager.js src/js/core/appRegistry.js src/js/core/desktop.js` *(parsing error: 'import' and 'export' may appear only with 'sourceType: module')*


------
https://chatgpt.com/codex/tasks/task_e_68b5a21dd37883309c2a1cbab9f04f3f