### PR TITLE
feat(ui): start menu and tray wired to registry

### DIFF
--- a/src/js/core/startMenu.js
+++ b/src/js/core/startMenu.js
@@ -1,0 +1,20 @@
+export function buildStartMenu(apps, launcher){
+  const ul = document.getElementById("start-app-list"); if (!ul) return;
+  ul.innerHTML = "";
+  for (const a of apps){
+    const li = document.createElement("li");
+    li.textContent = a.meta.name;
+    li.addEventListener("click", ()=> launcher.launch(a.meta.id));
+    ul.appendChild(li);
+  }
+}
+export function wireStartToggle(){
+  const btn = document.getElementById("start-button");
+  const menu = document.getElementById("start-menu");
+  if (!btn || !menu) return;
+  const toggle = ()=>menu.setAttribute("aria-hidden",
+    menu.getAttribute("aria-hidden")!=="false"?"false":"true");
+  btn.addEventListener("click", toggle);
+  document.addEventListener("keydown", e=>{ if (e.key==="Escape") menu.setAttribute("aria-hidden","true");});
+  document.addEventListener("click", e=>{ if (!menu.contains(e.target) && e.target!==btn) menu.setAttribute("aria-hidden","true"); });
+}

--- a/src/js/core/tray.js
+++ b/src/js/core/tray.js
@@ -1,0 +1,9 @@
+export function registerTray(launcher){
+  const hook = (id, appId)=>{
+    const el = document.getElementById(id);
+    if (el) el.onclick = ()=>launcher.launch(appId);
+  };
+  hook("tray-links-icon","link-manager");
+  hook("tray-volume-icon","volume");
+  hook("tray-snip-icon","recorder");
+}


### PR DESCRIPTION
## Summary
- Build start menu dynamically from app registry and wire toggle interactions
- Wire system tray icons to launch linked utilities via the app launcher

## Testing
- `npm test` *(fails: Missing script "test")*
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b5a3d88cc88330a1eef63d85a4bbe2