### PR TITLE
Add robust bootstrap gating and registry-driven UI

### DIFF
--- a/data/app-registry.json
+++ b/data/app-registry.json
@@ -1,0 +1,5 @@
+[
+  {"id":"notepad","title":"Notepad","icon":"notepad.png","entry":"/src/js/apps/notepad.js","comingSoon":true},
+  {"id":"file-manager","title":"File Manager","icon":"file-manager.png","entry":"/src/js/apps/file-manager.js","comingSoon":false},
+  {"id":"terminal","title":"Terminal","icon":"terminal.png","entry":"/src/js/apps/terminal.js","comingSoon":false}
+]

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
       </div>
     </div>
     <div id="start-menu" aria-hidden="true"><ul id="start-app-list"></ul></div>
-    <script type="module" src="/js/bootstrap.js"></script>
+    <script type="module" src="/src/bootstrap/bootstrap.js"></script>
   </body>
 </html>
 

--- a/src/bootstrap/bootstrap.js
+++ b/src/bootstrap/bootstrap.js
@@ -1,0 +1,65 @@
+import { gate } from './logBoot.js';
+import { API_BASE, ASSET_BASE, REGISTRY_URL } from '../config.js';
+import { renderDesktopIcons } from '../js/core/desktop.js';
+import { registerTray } from '../js/core/tray.js';
+import { buildStartMenu, wireStartToggle } from '../js/core/startMenu.js';
+import { Launcher } from '../js/core/launcher.js';
+
+async function loadConfig(){
+  if (API_BASE === undefined || ASSET_BASE === undefined || REGISTRY_URL === undefined){
+    throw new Error('Missing config');
+  }
+  return { API_BASE, ASSET_BASE, REGISTRY_URL };
+}
+
+async function loadRegistry(){
+  console.log('Fetching registry', REGISTRY_URL);
+  const res = await fetch(REGISTRY_URL);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} for ${REGISTRY_URL}`);
+  }
+  const data = await res.json();
+  if(!Array.isArray(data)) throw new Error('Registry must be an array');
+  const apps = [];
+  for(const app of data){
+    const {id, title, icon, entry, comingSoon} = app;
+    const missing = [];
+    if(!id) missing.push('id');
+    if(!title) missing.push('title');
+    if(!icon) missing.push('icon');
+    if(!entry) missing.push('entry');
+    if(typeof comingSoon !== 'boolean') missing.push('comingSoon');
+    if(missing.length){
+      console.error(`Invalid app ${id||'unknown'} missing ${missing.join(',')}`);
+      continue;
+    }
+    apps.push({id, title, icon, entry, comingSoon});
+  }
+  return apps;
+}
+
+async function mountDesktop(ctx, apps, launcher){
+  renderDesktopIcons(apps, launcher);
+}
+
+async function mountTaskbar(ctx, apps, launcher){
+  registerTray(launcher);
+}
+
+async function mountStartMenu(ctx, apps, launcher){
+  buildStartMenu(apps, launcher);
+  wireStartToggle();
+}
+
+async function main(){
+  const ctx = {};
+  await gate('loadConfig', loadConfig);
+  const apps = await gate('loadRegistry', loadRegistry);
+  const launcher = new Launcher(ctx, apps);
+  await gate('mountDesktop', () => mountDesktop(ctx, apps, launcher));
+  await gate('mountTaskbar', () => mountTaskbar(ctx, apps, launcher));
+  await gate('mountStartMenu', () => mountStartMenu(ctx, apps, launcher));
+  window.__BOOT_OK__ = true;
+}
+
+main();

--- a/src/bootstrap/logBoot.js
+++ b/src/bootstrap/logBoot.js
@@ -1,0 +1,27 @@
+function banner(msg){
+  const el = document.createElement('div');
+  el.textContent = msg;
+  el.style.position = 'fixed';
+  el.style.top = '0';
+  el.style.left = '0';
+  el.style.right = '0';
+  el.style.background = 'red';
+  el.style.color = 'white';
+  el.style.padding = '4px';
+  el.style.fontFamily = 'sans-serif';
+  el.style.zIndex = '10000';
+  document.body.appendChild(el);
+}
+
+export async function gate(name, fn){
+  console.log(`[BOOT] ${name} start`);
+  try{
+    const res = await fn();
+    console.log(`[BOOT] ${name} finish`);
+    return res;
+  }catch(err){
+    console.error(`[BOOT] ${name} failed`, err);
+    banner(`${name} failed: ${err.message}`);
+    throw err;
+  }
+}

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,3 @@
+export const API_BASE = '';
+export const ASSET_BASE = '/icons';
+export const REGISTRY_URL = `${API_BASE}/data/app-registry.json`;

--- a/src/js/core/desktop.js
+++ b/src/js/core/desktop.js
@@ -1,14 +1,15 @@
-import { getAppById, loadApps } from "./appRegistry.js";
-export async function renderDesktopIcons(launcher){
+import { ASSET_BASE } from "../../config.js";
+export function renderDesktopIcons(apps, launcher){
   const root = document.getElementById("desktop"); if (!root) return;
   root.innerHTML = "";
-  for (const a of loadApps()){
+  for (const a of apps){
     const el = document.createElement("div");
-    el.className = "icon"; el.dataset.appId = a.meta.id;
-    el.innerHTML = `<img alt=""><span></span>`;
-    el.querySelector("img").src = a.meta.icon || "/icons/default.png";
-    el.querySelector("span").textContent = a.meta.name;
-    el.addEventListener("dblclick", ()=> launcher.launch(a.meta.id));
+    el.className = "desktop-icon"; el.dataset.appId = a.id;
+    el.innerHTML = `<img alt=""><span class="label"></span>`;
+    const img = el.querySelector("img");
+    img.src = a.icon.startsWith("http") ? a.icon : `${ASSET_BASE}/${a.icon.replace(/^\//,'')}`;
+    el.querySelector(".label").textContent = a.title;
+    el.addEventListener("dblclick", ()=> launcher.launch(a.id));
     root.appendChild(el);
   }
 }

--- a/src/js/core/launcher.js
+++ b/src/js/core/launcher.js
@@ -1,19 +1,25 @@
-import { getAppById } from "./appRegistry.js";
 import { WindowManager } from "./windowManager.js";
 
 export class Launcher{
-  constructor(ctx){
+  constructor(ctx, apps){
     this.ctx = ctx;
+    this.apps = apps;
     this.wm = new WindowManager();
     ctx.windowManager = this.wm;
   }
-  launch(id){
-    const app = getAppById(id);
+  async launch(id){
+    const app = this.apps.find(a => a.id === id);
     if(!app){
       return console.warn("Unknown app", id);
     }
-    const win = this.wm.open(app.meta);
-    app.mount?.(win.body, this.ctx);
-    app.launch?.(this.ctx, win);
+    try{
+      const mod = await import(app.entry);
+      const meta = mod.meta || { id: app.id, name: app.title, icon: app.icon };
+      const win = this.wm.open(meta);
+      mod.mount?.(win.body, this.ctx);
+      mod.launch?.(this.ctx, win);
+    }catch(err){
+      console.error('Failed to launch', id, err);
+    }
   }
 }

--- a/src/js/core/startMenu.js
+++ b/src/js/core/startMenu.js
@@ -1,10 +1,17 @@
+import { ASSET_BASE } from "../../config.js";
 export function buildStartMenu(apps, launcher){
   const ul = document.getElementById("start-app-list"); if (!ul) return;
   ul.innerHTML = "";
   for (const a of apps){
     const li = document.createElement("li");
-    li.textContent = a.meta.name;
-    li.addEventListener("click", ()=> launcher.launch(a.meta.id));
+    li.innerHTML = `<img alt=""><span></span>`;
+    li.querySelector("img").src = a.icon.startsWith("http") ? a.icon : `${ASSET_BASE}/${a.icon.replace(/^\//,'')}`;
+    li.querySelector("span").textContent = a.title;
+    if(!a.comingSoon){
+      li.addEventListener("click", ()=> launcher.launch(a.id));
+    } else {
+      li.classList.add("coming-soon");
+    }
     ul.appendChild(li);
   }
 }

--- a/style.css
+++ b/style.css
@@ -228,6 +228,7 @@ body {
   width: 100%;
   height: calc(100% - 40px);
   overflow: hidden;
+  background: var(--desktop-bg) url('/images/wallpaper.png') center/cover no-repeat;
 }
 
 /* Taskbar */
@@ -421,14 +422,15 @@ body {
 }
 
 /* Desktop icons */
-.icon {
+#desktop .desktop-icon {
   position: absolute;
-  width: 72px;
+  width: 88px;
+  text-align: center;
+  user-select: none;
+  cursor: pointer;
   display: flex;
   flex-direction: column;
   align-items: center;
-  cursor: pointer;
-  user-select: none;
 }
 
 /* ERIKOS: Grid layout uses absolute positioning with padding for snapping */
@@ -438,7 +440,7 @@ body {
   padding: 8px; /* ERIKOS: margin around grid */
 }
 
-#desktop[data-layout="grid"] .icon {
+#desktop[data-layout="grid"] .desktop-icon {
   position: absolute;
   margin: 0; /* ERIKOS: avoid extra drift */
 }
@@ -515,20 +517,21 @@ body {
 }
 
 /* Visual feedback when dragging icons */
-.icon.dragging {
+#desktop .desktop-icon.dragging {
   opacity: 0.7;
   pointer-events: none;
 }
-
-.icon img {
-  width: 48px;
-  height: 48px;
+#desktop .desktop-icon img {
+  width: 64px;
+  height: 64px;
+  image-rendering: pixelated;
+  object-fit: contain;
 }
 
-.icon span {
+#desktop .desktop-icon .label {
+  display: block;
+  font: 12px/1.2 "MS Sans Serif", system-ui;
   margin-top: 4px;
-  text-align: center;
-  font-size: 12px;
   color: var(--icon-text);
 }
 


### PR DESCRIPTION
## Summary
- bootstrap now runs through gated stages and exposes errors with a red banner
- configuration and app registry loading centralised in `config.js`
- desktop icons styled with fixed dimensions to prevent global CSS from stretching them

## Testing
- ⚠️ `./run_tests.sh` *(Virtual environment not found. Please run install.sh first.)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b361a7908330b2f290aebaba97a9