### PR TITLE
Port core apps to new modular placeholders

### DIFF
--- a/js/apps/calculator.js
+++ b/js/apps/calculator.js
@@ -1,5 +1,6 @@
 import { openAppWindow } from '../utils/appWindow.js';
 
+// Placeholder for the Calculator app.
 export function openCalculator() {
-  openAppWindow('calculator', 'Calculator');
+  openAppWindow('calculator', 'Calculator', 'Calculator app coming soon');
 }

--- a/js/apps/chat.js
+++ b/js/apps/chat.js
@@ -1,5 +1,6 @@
 import { openAppWindow } from '../utils/appWindow.js';
 
+// Placeholder for the Chat app within the modular architecture.
 export function openChat() {
-  openAppWindow('chat', 'Chat');
+  openAppWindow('chat', 'Chat', 'Chat app coming soon');
 }

--- a/js/apps/gallery.js
+++ b/js/apps/gallery.js
@@ -1,5 +1,6 @@
 import { openAppWindow } from '../utils/appWindow.js';
 
+// Placeholder for the Gallery app.
 export function openGallery() {
-  openAppWindow('gallery', 'Gallery');
+  openAppWindow('gallery', 'Gallery', 'Gallery app coming soon');
 }

--- a/js/apps/mediaPlayer.js
+++ b/js/apps/mediaPlayer.js
@@ -1,5 +1,6 @@
 import { openAppWindow } from '../utils/appWindow.js';
 
+// Media Player placeholder window.
 export function openMediaPlayer() {
-  openAppWindow('media-player', 'Media Player');
+  openAppWindow('media-player', 'Media Player', 'Media Player app coming soon');
 }

--- a/js/apps/paint.js
+++ b/js/apps/paint.js
@@ -1,5 +1,6 @@
 import { openAppWindow } from '../utils/appWindow.js';
 
+// Placeholder for the Paint app.
 export function openPaint() {
-  openAppWindow('paint', 'Paint');
+  openAppWindow('paint', 'Paint', 'Paint app coming soon');
 }

--- a/js/apps/settings.js
+++ b/js/apps/settings.js
@@ -1,5 +1,6 @@
 import { openAppWindow } from '../utils/appWindow.js';
 
+// Placeholder implementation for the Settings app.
 export function openSettings() {
-  openAppWindow('settings', 'Settings');
+  openAppWindow('settings', 'Settings', 'Settings app coming soon');
 }

--- a/js/apps/sheets.js
+++ b/js/apps/sheets.js
@@ -1,5 +1,6 @@
 import { openAppWindow } from '../utils/appWindow.js';
 
+// Placeholder for the Sheets app.
 export function openSheets() {
-  openAppWindow('sheets', 'Sheets');
+  openAppWindow('sheets', 'Sheets', 'Sheets app coming soon');
 }

--- a/js/apps/terminal.js
+++ b/js/apps/terminal.js
@@ -1,5 +1,6 @@
 import { openAppWindow } from '../utils/appWindow.js';
 
+// Open a placeholder window for the Terminal app in the new modular setup.
 export function openTerminal() {
-  openAppWindow('terminal', 'Terminal');
+  openAppWindow('terminal', 'Terminal', 'Terminal app coming soon');
 }


### PR DESCRIPTION
## Summary
- Add modular placeholder modules for Terminal, Settings, Chat, Media Player, Calculator, Paint, Gallery, and Sheets
- Each module uses `openAppWindow` with a "coming soon" message

## Testing
- `bash run_tests.sh` *(fails: Virtual environment not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c8df84a08330acc609af07019bc9