### PR TITLE
feat: port app implementations

### DIFF
--- a/src/js/apps/calculator.js
+++ b/src/js/apps/calculator.js
@@ -7,7 +7,66 @@ export function launch(ctx) {
   mount(win, ctx);
 }
 export function mount(winEl, ctx) {
-  const msg = document.createElement('div');
-  msg.textContent = `${meta.name} app coming soon`;
-  winEl.appendChild(msg);
+  addLog('Calculator opened');
+  const container = winEl.classList.contains('window')
+    ? winEl.querySelector('.content')
+    : winEl;
+  if (!container) return;
+  container.innerHTML = '';
+  container.style.display = 'flex';
+  container.style.flexDirection = 'column';
+  container.style.width = '200px';
+
+  const display = document.createElement('input');
+  display.type = 'text';
+  display.readOnly = true;
+  display.value = '0';
+  display.style.textAlign = 'right';
+  display.style.fontSize = '20px';
+  display.style.marginBottom = '4px';
+
+  const buttons = [
+    ['7', '8', '9', '/'],
+    ['4', '5', '6', '*'],
+    ['1', '2', '3', '-'],
+    ['0', '.', '=', '+'],
+    ['C'],
+  ];
+
+  const grid = document.createElement('div');
+  grid.style.display = 'grid';
+  grid.style.gridTemplateColumns = 'repeat(4,1fr)';
+  grid.style.gap = '4px';
+
+  buttons.flat().forEach((label) => {
+    const btn = document.createElement('button');
+    btn.textContent = label;
+    btn.style.fontSize = '18px';
+    btn.style.padding = '8px';
+    btn.addEventListener('click', () => {
+      if (label === 'C') {
+        display.value = '0';
+      } else if (label === '=') {
+        try {
+          const expr = display.value;
+          if (/^[0-9.\/*+\-\s]+$/.test(expr)) {
+            display.value = String(eval(expr));
+          } else {
+            display.value = 'Err';
+          }
+        } catch (err) {
+          display.value = 'Err';
+        }
+      } else {
+        if (display.value === '0' && /[0-9]/.test(label)) {
+          display.value = label;
+        } else {
+          display.value += label;
+        }
+      }
+    });
+    grid.append(btn);
+  });
+
+  container.append(display, grid);
 }

--- a/src/js/apps/chat.js
+++ b/src/js/apps/chat.js
@@ -7,7 +7,433 @@ export function launch(ctx) {
   mount(win, ctx);
 }
 export function mount(winEl, ctx) {
-  const msg = document.createElement('div');
-  msg.textContent = `${meta.name} app coming soon`;
-  winEl.appendChild(msg);
+  addLog('Chat opened');
+  applyChatColors();
+
+  const container = winEl.classList.contains('window')
+    ? winEl.querySelector('.content')
+    : winEl;
+  if (!container) return;
+  container.innerHTML = '';
+  container.style.cssText = 'display:flex; height:100%; gap:2px;';
+
+  const historyPanel = document.createElement('div');
+  historyPanel.style.cssText = `
+    width: 30%;
+    min-width: 200px;
+    background: var(--window-bg);
+    border-right: 2px solid var(--window-border-dark);
+    display: flex;
+    flex-direction: column;
+  `;
+
+  const newChatBtn = document.createElement('button');
+  newChatBtn.textContent = '+ New Chat';
+  newChatBtn.style.cssText = `
+    margin: 4px;
+    padding: 6px;
+    background: var(--button-bg);
+    border: 2px solid;
+    border-color: var(--btn-border-light) var(--btn-border-dark) var(--btn-border-dark) var(--btn-border-light);
+  `;
+  historyPanel.append(newChatBtn);
+
+  const convList = document.createElement('div');
+  convList.style.cssText = 'flex:1; overflow-y:auto; padding:4px;';
+  historyPanel.append(convList);
+
+  const chatPanel = document.createElement('div');
+  chatPanel.style.cssText = 'flex:1; display:flex; flex-direction:column;';
+
+  container.append(historyPanel, chatPanel);
+
+  if (!currentUser.conversations) currentUser.conversations = [];
+  let currentConversation = null;
+
+  function renderConversationList() {
+    convList.innerHTML = '';
+    currentUser.conversations.forEach((conv) => {
+      const item = document.createElement('div');
+      item.className = 'chat-conversation-item';
+      if (conv === currentConversation) item.classList.add('active');
+
+      const title = document.createElement('div');
+      title.textContent = conv.title || 'Untitled';
+      title.style.fontWeight = 'bold';
+
+      const date = document.createElement('div');
+      date.textContent = new Date(conv.timestamp).toLocaleDateString();
+      date.style.fontSize = '11px';
+
+      const deleteBtn = document.createElement('button');
+      deleteBtn.textContent = 'X';
+      deleteBtn.style.cssText = 'float:right; padding:2px 4px; font-size:10px;';
+      deleteBtn.onclick = (e) => {
+        e.stopPropagation();
+        if (confirm('Delete this conversation?')) {
+          const idx = currentUser.conversations.indexOf(conv);
+          currentUser.conversations.splice(idx, 1);
+          saveProfiles(profiles);
+          if (conv === currentConversation) {
+            startNewChat();
+          } else {
+            renderConversationList();
+          }
+        }
+      };
+
+      item.append(deleteBtn, title, date);
+      item.onclick = () => loadConversation(conv);
+      convList.append(item);
+    });
+  }
+
+  function generateTitle(message) {
+    return message.slice(0, 30) + (message.length > 30 ? '...' : '');
+  }
+
+  function renderChatArea() {
+    chatPanel.innerHTML = '';
+
+    const toolbar = document.createElement('div');
+    toolbar.classList.add('chat-toolbar');
+    const modelLabel = document.createElement('span');
+    modelLabel.textContent = 'Model: ';
+    const modelSelect = document.createElement('select');
+    modelSelect.disabled = true;
+    const settingsBtn = document.createElement('button');
+    settingsBtn.textContent = 'Settings';
+    settingsBtn.addEventListener('click', openChatSettings);
+    toolbar.append(modelLabel, modelSelect, settingsBtn);
+
+    const msgList = document.createElement('div');
+    msgList.classList.add('chat-messages');
+    msgList.style.flex = '1';
+    msgList.style.overflowY = 'auto';
+    msgList.style.padding = '4px';
+
+    const form = document.createElement('form');
+    form.style.display = 'flex';
+    form.style.gap = '4px';
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.placeholder = 'Type your message…';
+    input.style.flex = '1';
+    const imageInput = document.createElement('input');
+    imageInput.type = 'file';
+    imageInput.accept = 'image/*';
+    const sendBtn = document.createElement('button');
+    sendBtn.type = 'submit';
+    sendBtn.textContent = 'Send';
+    form.append(input, imageInput, sendBtn);
+
+    chatPanel.append(toolbar, msgList, form);
+
+    function appendMessage(role, text) {
+      const msgEl = document.createElement('div');
+      msgEl.className = 'chat-message ' + role;
+      msgEl.textContent = text;
+      msgList.append(msgEl);
+      msgList.scrollTop = msgList.scrollHeight;
+    }
+
+    currentConversation.messages.forEach((m) => appendMessage(m.role, m.content));
+
+    async function fetchModels() {
+      try {
+        const res = await fetch('/api/ollama/models');
+        const data = await res.json();
+        modelSelect.innerHTML = '';
+        const models = Array.isArray(data.models) ? data.models : [];
+        if (models.length) {
+          models.forEach((name) => {
+            const opt = document.createElement('option');
+            opt.value = name;
+            opt.textContent = name;
+            modelSelect.append(opt);
+          });
+          modelSelect.disabled = false;
+        } else {
+          const opt = document.createElement('option');
+          opt.value = '';
+          opt.textContent = 'No models';
+          modelSelect.append(opt);
+          modelSelect.disabled = true;
+          appendMessage(
+            'system',
+            data.error ||
+              'No models detected—please install models or check Ollama\'s configuration'
+          );
+        }
+      } catch (err) {
+        modelSelect.innerHTML = '';
+        const opt = document.createElement('option');
+        opt.value = '';
+        opt.textContent = 'Unavailable';
+        modelSelect.append(opt);
+        modelSelect.disabled = true;
+        appendMessage('system', 'Failed to fetch models');
+      }
+    }
+    fetchModels();
+
+    function fileToBase64(file) {
+      return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+      });
+    }
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const msg = input.value.trim();
+      let imageData = null;
+      if (imageInput.files[0]) {
+        try {
+          imageData = await fileToBase64(imageInput.files[0]);
+          imageData = imageData.split(',')[1];
+        } catch (err) {
+          console.error(err);
+        }
+      }
+      if (!msg && !imageData) return;
+      if (msg) {
+        appendMessage('user', msg);
+        currentConversation.messages.push({ role: 'user', content: msg });
+        if (currentConversation.title === 'New Chat') {
+          currentConversation.title = generateTitle(msg);
+        }
+        saveProfiles(profiles);
+        renderConversationList();
+        input.value = '';
+      }
+      appendMessage('assistant', '…');
+      const placeholder = msgList.lastChild;
+      const selectedModel = modelSelect.value || 'llama2';
+      try {
+        const res = await fetch('/api/ollama/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            model: selectedModel,
+            prompt: msg,
+            history: currentConversation.messages,
+            image: imageData,
+            profile: currentUser ? currentUser.name : null,
+          }),
+        });
+        const data = await res.json();
+        placeholder.remove();
+        if (data.error) {
+          appendMessage('assistant', 'Error: ' + data.error);
+        } else {
+          const respText = data.response || '';
+          appendMessage('assistant', respText);
+          currentConversation.messages.push({
+            role: 'assistant',
+            content: respText,
+          });
+          saveProfiles(profiles);
+          renderConversationList();
+        }
+      } catch (err) {
+        placeholder.remove();
+        appendMessage('assistant', 'Error contacting model');
+      } finally {
+        fetchModels();
+      }
+      imageInput.value = '';
+    });
+  }
+
+  function loadConversation(conv) {
+    currentConversation = conv;
+    renderConversationList();
+    renderChatArea();
+  }
+
+  function startNewChat() {
+    currentConversation = {
+      id: Date.now(),
+      title: 'New Chat',
+      messages: [],
+      timestamp: new Date().toISOString(),
+    };
+    currentUser.conversations.unshift(currentConversation);
+    saveProfiles(profiles);
+    renderConversationList();
+    renderChatArea();
+  }
+
+  function openChatSettings() {
+    const winContent = document.createElement('div');
+    winContent.style.cssText = 'display:flex; flex-direction:column; height:100%;';
+    const tabBar = document.createElement('div');
+    const appearanceTab = document.createElement('button');
+    appearanceTab.textContent = 'Appearance';
+    const modelsTab = document.createElement('button');
+    modelsTab.textContent = 'Models';
+    tabBar.append(appearanceTab, modelsTab);
+    const tabBody = document.createElement('div');
+    tabBody.style.cssText = 'flex:1; overflow:auto; padding:4px;';
+    winContent.append(tabBar, tabBody);
+
+    function showTab(tab) {
+      appearanceContent.style.display = tab === 'appearance' ? 'block' : 'none';
+      modelsContent.style.display = tab === 'models' ? 'block' : 'none';
+      appearanceTab.disabled = tab === 'appearance';
+      modelsTab.disabled = tab === 'models';
+    }
+
+    const appearanceContent = document.createElement('div');
+    tabBody.append(appearanceContent);
+
+    function rgbToHex(rgb) {
+      const m = rgb.match(/\d+/g);
+      if (!m) return '#000000';
+      return '#' + m.slice(0, 3).map((x) => Number(x).toString(16).padStart(2, '0')).join('');
+    }
+
+    const defaults = (() => {
+      const cs = getComputedStyle(document.documentElement);
+      return {
+        userBg: rgbToHex(cs.getPropertyValue('--selection-bg')),
+        userText: rgbToHex(cs.getPropertyValue('--window-bg')),
+        assistantBg: rgbToHex(cs.getPropertyValue('--window-bg')),
+        assistantText: rgbToHex(cs.getPropertyValue('--icon-text')),
+      };
+    })();
+
+    const colors = Object.assign({}, defaults, currentUser.chatColors || {});
+
+    const fields = [
+      ['User Bubble BG', 'userBg'],
+      ['User Bubble Text', 'userText'],
+      ['Assistant Bubble BG', 'assistantBg'],
+      ['Assistant Bubble Text', 'assistantText'],
+    ];
+    const inputs = {};
+    fields.forEach(([labelText, key]) => {
+      const row = document.createElement('div');
+      row.style.marginBottom = '8px';
+      const label = document.createElement('label');
+      label.textContent = labelText + ': ';
+      const input = document.createElement('input');
+      input.type = 'color';
+      input.value = colors[key];
+      inputs[key] = input;
+      label.append(input);
+      row.append(label);
+      appearanceContent.append(row);
+    });
+    function saveColors() {
+      currentUser.chatColors = {
+        userBg: inputs.userBg.value,
+        userText: inputs.userText.value,
+        assistantBg: inputs.assistantBg.value,
+        assistantText: inputs.assistantText.value,
+      };
+      saveProfiles(profiles);
+      applyChatColors();
+      renderChatArea();
+    }
+    Object.values(inputs).forEach((input) => input.addEventListener('input', saveColors));
+
+    const modelsContent = document.createElement('div');
+    modelsContent.style.display = 'none';
+    tabBody.append(modelsContent);
+    const modelList = document.createElement('ul');
+    modelsContent.append(modelList);
+    const modelInput = document.createElement('input');
+    modelInput.type = 'text';
+    modelInput.placeholder = 'model name e.g. llama3.2:3b';
+    const pullBtn = document.createElement('button');
+    pullBtn.textContent = 'Pull';
+    const progress = document.createElement('progress');
+    progress.style.display = 'none';
+    progress.max = 100;
+    const output = document.createElement('pre');
+    output.style.whiteSpace = 'pre-wrap';
+    modelsContent.append(modelInput, pullBtn, progress, output);
+
+    async function loadModelList() {
+      modelList.innerHTML = '';
+      try {
+        const res = await fetch('/api/ollama/models');
+        const data = await res.json();
+        if (data.models && data.models.length) {
+          data.models.forEach((m) => {
+            const li = document.createElement('li');
+            li.textContent = m;
+            modelList.append(li);
+          });
+        } else {
+          const li = document.createElement('li');
+          li.textContent = data.error || 'No models';
+          modelList.append(li);
+        }
+      } catch (err) {
+        const li = document.createElement('li');
+        li.textContent = 'Failed to load models';
+        modelList.append(li);
+      }
+    }
+    loadModelList();
+
+    pullBtn.addEventListener('click', async () => {
+      const name = modelInput.value.trim();
+      if (!name) return;
+      modelInput.disabled = true;
+      pullBtn.disabled = true;
+      output.textContent = '';
+      progress.style.display = 'block';
+      try {
+        const res = await fetch('/api/execute-command', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ command: `ollama pull ${name}` }),
+        });
+        const data = await res.json();
+        if (!res.ok || !data.job_id) throw new Error(data.error || 'Failed');
+        const jobId = data.job_id;
+        const timer = setInterval(async () => {
+          const sres = await fetch(`/api/command-status/${jobId}`);
+          const sdata = await sres.json();
+          if (sdata.status === 'finished') {
+            clearInterval(timer);
+            progress.style.display = 'none';
+            modelInput.disabled = false;
+            pullBtn.disabled = false;
+            if (sdata.returncode === 0) {
+              await loadModelList();
+              renderChatArea();
+            } else {
+              output.textContent = sdata.output || 'Error';
+            }
+          }
+        }, 1000);
+      } catch (err) {
+        progress.style.display = 'none';
+        modelInput.disabled = false;
+        pullBtn.disabled = false;
+        output.textContent = String(err);
+      }
+    });
+
+    appearanceTab.addEventListener('click', () => showTab('appearance'));
+    modelsTab.addEventListener('click', () => showTab('models'));
+    showTab('appearance');
+
+    ctx.windowManager.createWindow('chat-settings', 'Chat Settings', winContent);
+  }
+
+  newChatBtn.onclick = startNewChat;
+
+  if (currentUser.conversations.length) {
+    loadConversation(currentUser.conversations[0]);
+  } else {
+    startNewChat();
+  }
 }

--- a/src/js/apps/gallery.js
+++ b/src/js/apps/gallery.js
@@ -7,7 +7,85 @@ export function launch(ctx) {
   mount(win, ctx);
 }
 export function mount(winEl, ctx) {
-  const msg = document.createElement('div');
-  msg.textContent = `${meta.name} app coming soon`;
-  winEl.appendChild(msg);
+  addLog('Gallery opened');
+  const container = winEl.classList.contains('window')
+    ? winEl.querySelector('.content')
+    : winEl;
+  if (!container) return;
+  container.innerHTML = '';
+  container.classList.add('file-manager');
+
+  const toolbar = document.createElement('div');
+  toolbar.classList.add('file-manager-toolbar');
+  const addBtn = document.createElement('button');
+  addBtn.textContent = 'Add Images';
+  toolbar.append(addBtn);
+
+  const content = document.createElement('div');
+  content.classList.add('file-manager-content');
+  content.style.display = 'flex';
+  content.style.flexWrap = 'wrap';
+  content.style.gap = '8px';
+  container.append(toolbar, content);
+
+  function renderThumbnail(src) {
+    const thumb = document.createElement('img');
+    thumb.src = src;
+    thumb.style.width = '80px';
+    thumb.style.height = '80px';
+    thumb.style.objectFit = 'cover';
+    thumb.style.cursor = 'pointer';
+    thumb.addEventListener('click', () => {
+      const viewer = document.createElement('img');
+      viewer.src = src;
+      viewer.style.maxWidth = '100%';
+      viewer.style.maxHeight = '100%';
+      const viewContainer = document.createElement('div');
+      viewContainer.style.display = 'flex';
+      viewContainer.style.justifyContent = 'center';
+      viewContainer.style.alignItems = 'center';
+      viewContainer.style.height = '100%';
+      viewContainer.append(viewer);
+      ctx.windowManager.createWindow('image', 'Image Viewer', viewContainer);
+    });
+    content.append(thumb);
+  }
+
+  addBtn.addEventListener('click', async () => {
+    if (window.showOpenFilePicker) {
+      try {
+        const handles = await window.showOpenFilePicker({
+          types: [
+            {
+              description: 'Images',
+              accept: { 'image/*': ['.png', '.jpg', '.jpeg', '.gif', '.bmp'] },
+            },
+          ],
+          multiple: true,
+        });
+        for (const handle of handles) {
+          const file = await handle.getFile();
+          const url = URL.createObjectURL(file);
+          renderThumbnail(url);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    } else {
+      const input = document.createElement('input');
+      input.type = 'file';
+      input.accept = 'image/*';
+      input.multiple = true;
+      input.style.display = 'none';
+      document.body.append(input);
+      input.addEventListener('change', () => {
+        Array.from(input.files).forEach((file) => {
+          const url = URL.createObjectURL(file);
+          renderThumbnail(url);
+        });
+        input.remove();
+      });
+      input.click();
+    }
+  });
 }

--- a/src/js/apps/media-player.js
+++ b/src/js/apps/media-player.js
@@ -7,7 +7,90 @@ export function launch(ctx) {
   mount(win, ctx);
 }
 export function mount(winEl, ctx) {
-  const msg = document.createElement('div');
-  msg.textContent = `${meta.name} app coming soon`;
-  winEl.appendChild(msg);
+  addLog('Media Player opened');
+  const container = winEl.classList.contains('window')
+    ? winEl.querySelector('.content')
+    : winEl;
+  if (!container) return;
+  container.innerHTML = '';
+  container.classList.add('file-manager');
+
+  const toolbar = document.createElement('div');
+  toolbar.classList.add('file-manager-toolbar');
+  const openBtn = document.createElement('button');
+  openBtn.textContent = 'Open Media';
+  toolbar.append(openBtn);
+
+  const content = document.createElement('div');
+  content.classList.add('file-manager-content');
+  container.append(toolbar, content);
+
+  let currentEl = null;
+
+  async function loadFile(file) {
+    if (!file) return;
+    const url = URL.createObjectURL(file);
+    content.innerHTML = '';
+    if (currentEl) {
+      currentEl.pause();
+      currentEl.src = '';
+      currentEl = null;
+    }
+    if (file.type.startsWith('video')) {
+      currentEl = document.createElement('video');
+      currentEl.controls = true;
+      currentEl.style.maxWidth = '100%';
+      currentEl.style.maxHeight = '100%';
+      currentEl.src = url;
+      addAudioElement(currentEl);
+      content.append(currentEl);
+      currentEl.play();
+    } else if (file.type.startsWith('audio')) {
+      currentEl = document.createElement('audio');
+      currentEl.controls = true;
+      currentEl.src = url;
+      addAudioElement(currentEl);
+      content.append(currentEl);
+      currentEl.play();
+    } else {
+      const p = document.createElement('p');
+      p.textContent = 'Unsupported file type.';
+      content.append(p);
+    }
+  }
+
+  openBtn.addEventListener('click', async () => {
+    try {
+      if (window.showOpenFilePicker) {
+        const [handle] = await window.showOpenFilePicker({
+          types: [
+            {
+              description: 'Media',
+              accept: {
+                'audio/*': ['.mp3', '.wav', '.ogg'],
+                'video/*': ['.mp4', '.webm', '.ogg'],
+              },
+            },
+          ],
+          multiple: false,
+        });
+        const file = await handle.getFile();
+        await loadFile(file);
+      } else {
+        const input = document.createElement('input');
+        input.type = 'file';
+        input.accept = 'audio/*,video/*';
+        input.style.display = 'none';
+        document.body.append(input);
+        input.addEventListener('change', () => {
+          const file = input.files[0];
+          loadFile(file);
+          input.remove();
+        });
+        input.click();
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  });
 }

--- a/src/js/apps/paint.js
+++ b/src/js/apps/paint.js
@@ -7,7 +7,150 @@ export function launch(ctx) {
   mount(win, ctx);
 }
 export function mount(winEl, ctx) {
-  const msg = document.createElement('div');
-  msg.textContent = `${meta.name} app coming soon`;
-  winEl.appendChild(msg);
+  addLog('Paint opened');
+  const container = winEl.classList.contains('window')
+    ? winEl.querySelector('.content')
+    : winEl;
+  const outer = winEl.classList.contains('window') ? winEl : winEl.closest('.window');
+  if (!container) return;
+  container.innerHTML = '';
+  container.style.display = 'flex';
+  container.style.flexDirection = 'column';
+  container.style.height = '100%';
+
+  const toolbar = document.createElement('div');
+  toolbar.style.display = 'flex';
+  toolbar.style.gap = '4px';
+
+  const brushBtn = document.createElement('button');
+  brushBtn.textContent = 'Brush';
+  brushBtn.title = 'Brush tool';
+  const eraserBtn = document.createElement('button');
+  eraserBtn.textContent = 'Eraser';
+  eraserBtn.title = 'Eraser tool';
+  const colorInput = document.createElement('input');
+  colorInput.type = 'color';
+  colorInput.value = '#000000';
+  const sizeInput = document.createElement('input');
+  sizeInput.type = 'range';
+  sizeInput.min = '1';
+  sizeInput.max = '30';
+  sizeInput.value = '4';
+  sizeInput.title = 'Brush size';
+  const insertImgBtn = document.createElement('button');
+  insertImgBtn.textContent = 'Insert Image';
+  insertImgBtn.title = 'Insert an image onto the canvas';
+  const clearBtn = document.createElement('button');
+  clearBtn.textContent = 'Clear';
+  const saveBtn = document.createElement('button');
+  saveBtn.textContent = 'Save';
+  toolbar.append(
+    brushBtn,
+    eraserBtn,
+    colorInput,
+    sizeInput,
+    insertImgBtn,
+    clearBtn,
+    saveBtn
+  );
+
+  const canvas = document.createElement('canvas');
+  canvas.width = 640;
+  canvas.height = 400;
+  canvas.style.border = '1px solid var(--window-border-dark)';
+  canvas.style.cursor = 'crosshair';
+  container.append(toolbar, canvas);
+
+  const ctx2d = canvas.getContext('2d');
+
+  function resizeCanvas() {
+    const rect = container.getBoundingClientRect();
+    canvas.width = rect.width;
+    canvas.height = rect.height - toolbar.offsetHeight;
+  }
+  resizeCanvas();
+  outer?.addEventListener('resized', () => setTimeout(resizeCanvas, 0));
+
+  ctx2d.lineCap = 'round';
+  let mode = 'brush';
+  function updateToolButtons() {
+    brushBtn.style.fontWeight = mode === 'brush' ? 'bold' : 'normal';
+    eraserBtn.style.fontWeight = mode === 'erase' ? 'bold' : 'normal';
+  }
+  updateToolButtons();
+
+  brushBtn.addEventListener('click', () => {
+    mode = 'brush';
+    updateToolButtons();
+  });
+  eraserBtn.addEventListener('click', () => {
+    mode = 'erase';
+    updateToolButtons();
+  });
+
+  insertImgBtn.addEventListener('click', () => {
+    const inputFile = document.createElement('input');
+    inputFile.type = 'file';
+    inputFile.accept = 'image/*';
+    inputFile.style.display = 'none';
+    document.body.append(inputFile);
+    inputFile.addEventListener('change', () => {
+      const file = inputFile.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = (ev) => {
+        const img = new Image();
+        img.onload = () => {
+          ctx2d.drawImage(img, 0, 0, img.width, img.height);
+        };
+        img.src = ev.target.result;
+      };
+      reader.readAsDataURL(file);
+      inputFile.remove();
+    });
+    inputFile.click();
+  });
+
+  let drawing = false;
+  let lastX = 0;
+  let lastY = 0;
+  function draw(x, y) {
+    if (!drawing) return;
+    ctx2d.globalCompositeOperation =
+      mode === 'erase' ? 'destination-out' : 'source-over';
+    ctx2d.strokeStyle = colorInput.value;
+    ctx2d.lineWidth = parseInt(sizeInput.value, 10);
+    ctx2d.beginPath();
+    ctx2d.moveTo(lastX, lastY);
+    ctx2d.lineTo(x, y);
+    ctx2d.stroke();
+    lastX = x;
+    lastY = y;
+  }
+
+  canvas.addEventListener('pointerdown', (e) => {
+    drawing = true;
+    lastX = e.offsetX;
+    lastY = e.offsetY;
+  });
+  canvas.addEventListener('pointermove', (e) => {
+    draw(e.offsetX, e.offsetY);
+  });
+  const stopDrawing = () => {
+    drawing = false;
+    ctx2d.globalCompositeOperation = 'source-over';
+  };
+  canvas.addEventListener('pointerup', stopDrawing);
+  canvas.addEventListener('pointerleave', stopDrawing);
+
+  clearBtn.addEventListener('click', () => {
+    ctx2d.clearRect(0, 0, canvas.width, canvas.height);
+  });
+
+  saveBtn.addEventListener('click', () => {
+    const link = document.createElement('a');
+    link.href = canvas.toDataURL('image/png');
+    link.download = 'painting.png';
+    link.click();
+  });
 }

--- a/src/js/apps/terminal.js
+++ b/src/js/apps/terminal.js
@@ -7,7 +7,75 @@ export function launch(ctx) {
   mount(win, ctx);
 }
 export function mount(winEl, ctx) {
-  const msg = document.createElement('div');
-  msg.textContent = `${meta.name} app coming soon`;
-  winEl.appendChild(msg);
+  const container = winEl.classList.contains('window')
+    ? winEl.querySelector('.content')
+    : winEl;
+  if (!container) return;
+  container.innerHTML = '';
+  container.classList.add('terminal-container');
+
+  const output = document.createElement('div');
+  output.classList.add('terminal-output');
+  const input = document.createElement('input');
+  input.classList.add('terminal-input');
+  input.type = 'text';
+  input.placeholder = 'Type a command...';
+  container.append(output, input);
+
+  const commands = {
+    help: () =>
+      'Available commands:\n' +
+      'help          Show this help message\n' +
+      'clear         Clear the terminal\n' +
+      'theme <name>  Change theme (default, matrix, highcontrast, red, pink, solarized, vaporwave)\n' +
+      'about         Show information about this desktop\n' +
+      'All other commands will be executed on the server (if allowed)',
+    clear: () => {
+      output.textContent = '';
+      return '';
+    },
+    theme: (name) => {
+      setTheme(name);
+      return `Theme changed to ${name}`;
+    },
+    about: () =>
+      'Win95‑Style Browser Desktop\nThis is a web‑based desktop environment inspired by Windows 95.\nImplemented using vanilla JavaScript and modern Web APIs.',
+  };
+
+  function print(text) {
+    output.textContent += text + '\n';
+    output.scrollTop = output.scrollHeight;
+  }
+
+  print('Win95‑Terminal. Type "help" for available commands.');
+
+  input.addEventListener('keydown', async (e) => {
+    if (e.key !== 'Enter') return;
+    const line = input.value.trim();
+    input.value = '';
+    if (!line) return;
+    print('> ' + line);
+    const [cmd, ...args] = line.split(' ');
+    const command = commands[cmd];
+    if (command) {
+      const result = command(...args);
+      if (typeof result === 'string') print(result);
+    } else {
+      try {
+        const resp = await fetch('/api/execute-command', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ command: line }),
+        });
+        const data = await resp.json();
+        if (data.error) {
+          print('Error: ' + data.error);
+        } else {
+          print(data.output || '');
+        }
+      } catch (err) {
+        print('Failed to execute command');
+      }
+    }
+  });
 }


### PR DESCRIPTION
## Summary
- migrate terminal, chat, media player, calculator, paint, and gallery apps to modular structure
- include command execution, chat with settings/models, multimedia playback, calculator, canvas drawing, and image viewer

## Testing
- `./run_tests.sh` *(fails: Virtual environment not found)*
- `./install.sh` *(fails: Could not find a version that satisfies the requirement Flask==3.0.2)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cbad34a88330893ca31cda75234a