### PR TITLE
feat: enhance start menu and tray

### DIFF
--- a/src/js/bootstrap.js
+++ b/src/js/bootstrap.js
@@ -45,7 +45,7 @@ export function bootstrap(){
 
   console.time("start");
   buildStartMenu(apps, launcher);
-  wireStartToggle();
+  wireStartToggle(launcher, apps);
   console.timeEnd("start");
 
   console.time("tray");

--- a/src/js/core/startMenu.js
+++ b/src/js/core/startMenu.js
@@ -1,28 +1,126 @@
 import { ASSET_BASE } from "../../config.js";
-export function buildStartMenu(apps, launcher){
-  const ul = document.getElementById("start-app-list"); if (!ul) return;
+
+export function filterApps(apps, query = "") {
+  const q = query.toLowerCase();
+  return apps.filter((a) => a.title.toLowerCase().includes(q));
+}
+
+function trackRecent(id) {
+  try {
+    const data = JSON.parse(localStorage.getItem("recent-apps") || "[]");
+    const idx = data.indexOf(id);
+    if (idx !== -1) data.splice(idx, 1);
+    data.unshift(id);
+    localStorage.setItem("recent-apps", JSON.stringify(data.slice(0, 5)));
+  } catch (_) {
+    /* ignore */
+  }
+}
+
+function renderRecent(apps, launcher) {
+  const ul = document.getElementById("start-recent-list");
+  if (!ul) return;
   ul.innerHTML = "";
-  for (const a of apps){
+  let ids = [];
+  try {
+    ids = JSON.parse(localStorage.getItem("recent-apps") || "[]");
+  } catch (_) {
+    /* ignore */
+  }
+  for (const id of ids) {
+    const app = apps.find((a) => a.id === id);
+    if (!app) continue;
     const li = document.createElement("li");
     li.innerHTML = `<img alt=""><span></span>`;
-    li.querySelector("img").src = a.icon.startsWith("http") ? a.icon : `${ASSET_BASE}/${a.icon.replace(/^\//,'')}`;
+    li.querySelector("img").src = app.icon.startsWith("http")
+      ? app.icon
+      : `${ASSET_BASE}/${app.icon.replace(/^\//, "")}`;
+    li.querySelector("span").textContent = app.title;
+    li.tabIndex = 0;
+    li.addEventListener("click", () => launcher.launch(app.id));
+    ul.appendChild(li);
+  }
+}
+
+export function buildStartMenu(apps, launcher, query = "") {
+  const ul = document.getElementById("start-app-list");
+  if (!ul) return;
+  ul.innerHTML = "";
+  for (const a of filterApps(apps, query)) {
+    const li = document.createElement("li");
+    li.innerHTML = `<img alt=""><span></span>`;
+    li.querySelector("img").src = a.icon.startsWith("http")
+      ? a.icon
+      : `${ASSET_BASE}/${a.icon.replace(/^\//, "")}`;
     li.querySelector("span").textContent = a.title;
-    if(!a.comingSoon){
-      li.addEventListener("click", ()=> launcher.launch(a.id));
+    if (!a.comingSoon) {
+      li.tabIndex = 0;
+      li.addEventListener("click", () => {
+        launcher.launch(a.id);
+        trackRecent(a.id);
+        renderRecent(apps, launcher);
+      });
     } else {
       li.classList.add("coming-soon");
     }
     ul.appendChild(li);
   }
+  renderRecent(apps, launcher);
 }
-export function wireStartToggle(){
+
+export function wireStartToggle(launcher, apps = []) {
   const btn = document.getElementById("start-button");
   const menu = document.getElementById("start-menu");
+  const search = document.getElementById("start-search");
+  const user = document.getElementById("start-user");
+  const shutdown = document.getElementById("start-shutdown");
+  const logout = document.getElementById("start-logout");
+  if (user && window.currentUser) user.textContent = window.currentUser.name || "";
+  if (shutdown) shutdown.addEventListener("click", () => window.dispatchEvent(new CustomEvent("shutdown")));
+  if (logout) logout.addEventListener("click", () => window.dispatchEvent(new CustomEvent("logout")));
   if (!btn || !menu) return;
-  menu.setAttribute("role","menu");
-  const open = ()=>{ menu.hidden = false; };
-  const close = ()=>{ menu.hidden = true; };
-  btn.addEventListener("click", e=>{ e.stopPropagation(); menu.hidden ? open() : close(); });
-  document.addEventListener("keydown", e=>{ if (e.key==="Escape") close(); });
-  document.addEventListener("click", e=>{ if (!menu.contains(e.target) && e.target!==btn) close(); });
+  menu.setAttribute("role", "menu");
+  const open = () => {
+    menu.hidden = false;
+    search?.focus();
+  };
+  const close = () => {
+    menu.hidden = true;
+  };
+  btn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    menu.hidden ? open() : close();
+  });
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") close();
+    if (e.key === "Meta" && !e.ctrlKey && !e.altKey) {
+      e.preventDefault();
+      menu.hidden ? open() : close();
+    }
+    if (e.ctrlKey && e.code === "Space") {
+      e.preventDefault();
+      open();
+    }
+    if (e.ctrlKey && e.shiftKey && e.key === "S") {
+      e.preventDefault();
+      launcher.launch("recorder");
+    }
+  });
+  document.addEventListener("click", (e) => {
+    if (!menu.contains(e.target) && e.target !== btn) close();
+  });
+  menu.addEventListener("keydown", (e) => {
+    const items = Array.from(menu.querySelectorAll("li:not(.coming-soon)"));
+    let idx = items.indexOf(document.activeElement);
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      idx = (idx + 1) % items.length;
+      items[idx].focus();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      idx = (idx - 1 + items.length) % items.length;
+      items[idx].focus();
+    }
+  });
+  search?.addEventListener("input", () => buildStartMenu(apps, launcher, search.value));
 }

--- a/src/js/core/tray.js
+++ b/src/js/core/tray.js
@@ -6,4 +6,21 @@ export function registerTray(launcher){
   hook("tray-links-icon","link-manager");
   hook("tray-volume-icon","volume");
   hook("tray-snip-icon","recorder");
+
+  const clock = document.getElementById("tray-clock");
+  if (clock){
+    const update=()=>{
+      const d = new Date();
+      clock.textContent = d.toLocaleTimeString([], {hour:"2-digit",minute:"2-digit"});
+    };
+    update();
+    setInterval(update,60000);
+    clock.addEventListener("click",()=>launcher.launch("calendar"));
+  }
+
+  const net = document.getElementById("tray-network");
+  const updNet=()=>{ if(net) net.textContent = navigator.onLine?"Online":"Offline"; };
+  updNet();
+  window.addEventListener("online", updNet);
+  window.addEventListener("offline", updNet);
 }

--- a/src/js/core/windowManager.js
+++ b/src/js/core/windowManager.js
@@ -248,6 +248,10 @@ export class WindowManager {
       idx = (idx + 1) % wins.length;
       this.focusWindow(wins[idx].id);
     }
+    if (e.altKey && e.key === "F4") {
+      e.preventDefault();
+      if (this.activeId) this.closeWindow(this.activeId);
+    }
   }
 
   _ensureInViewport(info) {

--- a/src/js/utils/api.js
+++ b/src/js/utils/api.js
@@ -15,6 +15,7 @@ export class APIClient {
   }
 
   async request(endpoint, options = {}, responseType = 'json') {
+    const start = performance.now();
     try {
       const opts = { ...options };
       const headers = { ...(opts.headers || {}) };
@@ -38,9 +39,10 @@ export class APIClient {
         default:
           data = await res.json();
       }
+      console.debug('API', endpoint, 'took', Math.round(performance.now() - start), 'ms');
       return { ok: true, data };
     } catch (err) {
-      console.error('API error', endpoint, err);
+      console.error('API error', { endpoint, options }, err);
       return { ok: false, error: String(err) };
     }
   }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,6 +29,20 @@ def test_list_icons(client):
     assert isinstance(data.get("icons"), list)
 
 
+def test_health_endpoint(client):
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data.get("ok") is True
+
+
+def test_version_endpoint(client):
+    resp = client.get("/api/version")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "version" in data
+
+
 def test_file_manager_invalid_paths(client):
     headers = {"X-User-Id": "tester"}
     resp = client.get("/api/list-directory", query_string={"path": "../"}, headers=headers)

--- a/tests/test_frontend.js
+++ b/tests/test_frontend.js
@@ -1,0 +1,11 @@
+import assert from 'assert';
+import { filterApps } from '../src/js/core/startMenu.js';
+
+const apps = [
+  { id: 'a', title: 'Alpha' },
+  { id: 'b', title: 'Beta' },
+];
+
+assert.deepStrictEqual(filterApps(apps, 'al'), [apps[0]]);
+assert.deepStrictEqual(filterApps(apps, 'B'), [apps[1]]);
+console.log('frontend tests passed');


### PR DESCRIPTION
## Summary
- add clock and network status to tray
- expand start menu with search, recent apps, and keyboard shortcuts
- log API errors with context and measure request time
- support Alt+F4 window close and expose filterApps utility
- cover API health/version endpoints and basic frontend filtering test

## Testing
- `node tests/test_frontend.js`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b5dd8d55088330bff1f9a953742b1d