### PR TITLE
Constrain dynamic tray icons and taskbar buttons

### DIFF
--- a/src/js/core/tray.js
+++ b/src/js/core/tray.js
@@ -1,3 +1,17 @@
+function constrainTrayIcon(element) {
+  if (element && element.tagName === 'IMG') {
+    element.style.width = '20px';
+    element.style.height = '20px';
+    element.style.minWidth = '20px';
+    element.style.minHeight = '20px';
+    element.style.maxWidth = '20px';
+    element.style.maxHeight = '20px';
+    element.style.flex = 'none';
+    element.style.flexShrink = '0';
+    element.style.objectFit = 'contain';
+  }
+}
+
 export function registerTray(launcher){
   const hook = (id, appId)=>{
     const el = document.getElementById(id);
@@ -6,6 +20,11 @@ export function registerTray(launcher){
   hook("tray-links-icon","link-manager");
   hook("tray-volume-icon","volume");
   hook("tray-snip-icon","recorder");
+
+  // Constrain all tray icons
+  constrainTrayIcon(document.getElementById('tray-links-icon'));
+  constrainTrayIcon(document.getElementById('tray-volume-icon'));
+  constrainTrayIcon(document.getElementById('tray-snip-icon'));
 
   const clock = document.getElementById("tray-clock");
   if (clock){

--- a/src/js/core/windowManager.js
+++ b/src/js/core/windowManager.js
@@ -111,6 +111,10 @@ export class WindowManager {
     btn.className = "task-btn";
     btn.textContent = title;
     btn.dataset.win = id;
+    // Add size constraints
+    btn.style.maxWidth = '180px';
+    btn.style.height = '24px';
+    btn.style.flexShrink = '0';
     btn.addEventListener("click", () => this.toggleWindow(id));
     this.taskbar?.appendChild(btn);
     return btn;


### PR DESCRIPTION
## Summary
- Add helper to constrain tray icon sizes and apply to default tray items
- Enforce max dimensions on dynamically created taskbar buttons for consistent layout

## Testing
- `./run_tests.sh` *(fails: Virtual environment not found. Please run install.sh first.)*

------
https://chatgpt.com/codex/tasks/task_e_68b6680e80e48330b429cb43cd7d5dd5