### PR TITLE
Add icon loading validation

### DIFF
--- a/src/js/bootstrap.js
+++ b/src/js/bootstrap.js
@@ -1,4 +1,5 @@
 import { loadApps } from "./core/appRegistry.js";
+import { IconManager } from "./utils/iconManager.js";
 import { renderDesktopIcons } from "./core/desktop.js";
 import { buildStartMenu, wireStartToggle } from "./core/startMenu.js";
 import { registerTray } from "./core/tray.js";
@@ -56,6 +57,8 @@ export function bootstrap(){
 
 document.addEventListener("DOMContentLoaded", () => {
   bootstrap();
+  // Fix any oversized icons
+  IconManager.fixAllIcons();
   setTimeout(() => {
     if (document.querySelectorAll("#desktop .icon").length === 0) {
       overlay("Bootstrap stalled — check IDs, assets, registry.");

--- a/src/js/utils/iconManager.js
+++ b/src/js/utils/iconManager.js
@@ -1,0 +1,88 @@
+/**
+ * Icon size management utility for ErikOS
+ * Ensures all taskbar and tray icons maintain consistent sizing
+ */
+
+export class IconManager {
+  static SIZES = {
+    tray: 20,
+    taskbar: 18,
+    desktop: 64
+  };
+
+  static constrainIcon(img, type = "tray") {
+    const size = this.SIZES[type] || 20;
+
+    // Apply size constraints
+    const styles = {
+      width: `${size}px`,
+      height: `${size}px`,
+      minWidth: `${size}px`,
+      minHeight: `${size}px`,
+      maxWidth: `${size}px`,
+      maxHeight: `${size}px`,
+      flex: "none",
+      flexShrink: "0",
+      objectFit: "contain",
+      display: "inline-block",
+      imageRendering: "pixelated"
+    };
+
+    Object.assign(img.style, styles);
+
+    // Force re-render if image is already loaded
+    if (img.complete) {
+      img.style.display = "none";
+      img.offsetHeight; // Force reflow
+      img.style.display = "inline-block";
+    }
+
+    return img;
+  }
+
+  static fixAllIcons() {
+    // Fix tray icons
+    document.querySelectorAll("#tray img").forEach((img) => {
+      this.constrainIcon(img, "tray");
+    });
+
+    // Fix taskbar icons if any
+    document.querySelectorAll("#taskbar-windows img").forEach((img) => {
+      this.constrainIcon(img, "taskbar");
+    });
+  }
+
+  static observeIconContainer(container) {
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        mutation.addedNodes.forEach((node) => {
+          if (node.tagName === "IMG") {
+            const type = node.closest("#tray") ? "tray" : "taskbar";
+            this.constrainIcon(node, type);
+          }
+        });
+      });
+    });
+
+    observer.observe(container, {
+      childList: true,
+      subtree: true
+    });
+
+    return observer;
+  }
+}
+
+// Auto-fix on load
+if (typeof window !== "undefined") {
+  window.addEventListener("DOMContentLoaded", () => {
+    IconManager.fixAllIcons();
+
+    // Watch for new icons
+    const tray = document.getElementById("tray");
+    const taskbar = document.getElementById("taskbar-windows");
+
+    if (tray) IconManager.observeIconContainer(tray);
+    if (taskbar) IconManager.observeIconContainer(taskbar);
+  });
+}


### PR DESCRIPTION
## Summary
- add `IconManager` utility to enforce consistent tray/taskbar icon sizes and monitor new icons
- invoke `IconManager` during bootstrap to prevent oversized icons on load

## Testing
- `./install.sh` *(failed: Could not find Flask==3.0.2)*
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b669f3dd9c8330ac9238f3c126e123