### PR TITLE
refactor: wrap tray icons with explicit sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,10 +14,31 @@
     <div id="taskbar">
       <button id="start-button">Start</button>
       <div id="taskbar-windows"></div>
-      <div id="tray">
-        <img id="tray-links-icon" alt="Links" src="/icons/link-manager.png" />
-        <img id="tray-volume-icon" alt="Volume" src="/icons/media-player.png" />
-        <img id="tray-snip-icon" alt="Snip" src="/icons/recorder.png" />
+      <div id="tray" class="system-tray">
+        <div class="tray-icon-wrapper">
+          <img id="tray-links-icon" 
+               alt="Links" 
+               src="/icons/link-manager.png" 
+               width="20" 
+               height="20" 
+               class="tray-icon" />
+        </div>
+        <div class="tray-icon-wrapper">
+          <img id="tray-volume-icon" 
+               alt="Volume" 
+               src="/icons/media-player.png" 
+               width="20" 
+               height="20" 
+               class="tray-icon" />
+        </div>
+        <div class="tray-icon-wrapper">
+          <img id="tray-snip-icon" 
+               alt="Snip" 
+               src="/icons/recorder.png" 
+               width="20" 
+               height="20" 
+               class="tray-icon" />
+        </div>
       </div>
     </div>
     <div id="start-menu" role="menu" hidden><ul id="start-app-list"></ul></div>

--- a/style.css
+++ b/style.css
@@ -312,6 +312,21 @@ body {
   flex: none;
 }
 
+.tray-icon-wrapper {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;  /* 20px icon + 1px padding each side */
+  height: 22px;
+  flex: none;
+}
+
+.tray-icon {
+  width: 20px !important;
+  height: 20px !important;
+  display: block;
+}
+
 /* Fix taskbar window buttons */
 #taskbar-windows {
   flex: 1;


### PR DESCRIPTION
## Summary
- refactor tray HTML to wrap each icon in a container and specify explicit size attrs
- add CSS helpers for tray icon wrappers and icons

## Testing
- `./run_tests.sh` *(fails: Virtual environment not found. Please run install.sh first.)*

------
https://chatgpt.com/codex/tasks/task_e_68b66c2bc7388330a9f2b53029328fd9