### PR TITLE
Enable single-click icons and content wrapper

### DIFF
--- a/src/js/apps/calendar.js
+++ b/src/js/apps/calendar.js
@@ -7,7 +7,7 @@ export function launch(ctx) {
   mount(win, ctx);
 }
 export function mount(winEl, ctx) {
-  const container = winEl;
+  const container = winEl.querySelector('.content');
   container.style.display = 'flex';
   container.style.flexDirection = 'column';
   container.style.height = '100%';

--- a/src/js/apps/clock.js
+++ b/src/js/apps/clock.js
@@ -7,7 +7,7 @@ export function launch(ctx) {
   mount(win, ctx);
 }
 export function mount(winEl, ctx) {
-  const container = winEl;
+  const container = winEl.querySelector('.content');
   container.style.display = 'flex';
   container.style.flexDirection = 'column';
   container.style.alignItems = 'center';

--- a/src/js/apps/crypto.js
+++ b/src/js/apps/crypto.js
@@ -7,7 +7,7 @@ export function launch(ctx) {
   mount(win, ctx);
 }
 export function mount(winEl, ctx) {
-  const container = winEl;
+  const container = winEl.querySelector('.content');
   container.style.cssText = 'display:flex; flex-direction:column; height:100%; padding:8px;';
 
   const totalPanel = document.createElement('div');

--- a/src/js/apps/diagnostics.js
+++ b/src/js/apps/diagnostics.js
@@ -10,7 +10,7 @@ export function launch(ctx) {
 }
 
 export function mount(winEl, ctx) {
-  const container = winEl;
+  const container = winEl.querySelector('.content');
   container.style.padding = '8px';
   container.textContent = 'Running diagnostics...';
   const api = new APIClient(ctx);

--- a/src/js/apps/file-manager.js
+++ b/src/js/apps/file-manager.js
@@ -13,7 +13,7 @@ export function launch(ctx) {
 }
 
 export function mount(winEl, ctx) {
-  const container = winEl;
+  const container = winEl.querySelector('.content');
   container.classList.add('file-manager');
 
   const api = new APIClient(ctx);

--- a/src/js/apps/link-manager.js
+++ b/src/js/apps/link-manager.js
@@ -8,7 +8,8 @@ export function launch(ctx) {
 }
 export function mount(winEl, ctx) {
   if (!currentUser) {
-    winEl.textContent = 'Please log in to manage links';
+    const container = winEl.querySelector('.content');
+    if (container) container.textContent = 'Please log in to manage links';
     return;
   }
 
@@ -18,7 +19,7 @@ export function mount(winEl, ctx) {
     return { type: 'link', name: item.name, url: item.url };
     });
 
-  const container = winEl;
+  const container = winEl.querySelector('.content');
   container.classList.add('file-manager');
   const toolbar = document.createElement('div');
   toolbar.classList.add('file-manager-toolbar');

--- a/src/js/apps/logs.js
+++ b/src/js/apps/logs.js
@@ -7,7 +7,7 @@ export function launch(ctx) {
   mount(win, ctx);
 }
 export function mount(winEl, ctx) {
-  const container = winEl;
+  const container = winEl.querySelector('.content');
   container.style.display = 'flex';
   container.style.flexDirection = 'column';
   container.style.height = '100%';

--- a/src/js/apps/notepad.js
+++ b/src/js/apps/notepad.js
@@ -9,7 +9,7 @@ export function launch(ctx, initialText = "") {
 }
 
 export function mount(winEl, ctx, initialText = "") {
-  const container = winEl;
+  const container = winEl.querySelector('.content');
   container.style.display = "flex";
   container.style.flexDirection = "column";
   container.style.height = "100%";

--- a/src/js/apps/processes.js
+++ b/src/js/apps/processes.js
@@ -9,7 +9,7 @@ export function launch(ctx) {
   mount(win, ctx);
 }
 export function mount(winEl, ctx) {
-  const container = winEl;
+  const container = winEl.querySelector('.content');
   container.style.display = 'flex';
   container.style.flexDirection = 'column';
   container.style.height = '100%';

--- a/src/js/apps/profiles.js
+++ b/src/js/apps/profiles.js
@@ -8,11 +8,12 @@ export function launch(ctx) {
 }
 export function mount(winEl, ctx) {
   if (!currentUser) {
-    winEl.textContent = 'No user logged in';
+    const container = winEl.querySelector('.content');
+    if (container) container.textContent = 'No user logged in';
     return;
   }
 
-  const container = winEl;
+  const container = winEl.querySelector('.content');
   container.classList.add('file-manager');
   const content = document.createElement('div');
   content.classList.add('file-manager-content');

--- a/src/js/apps/recorder.js
+++ b/src/js/apps/recorder.js
@@ -7,7 +7,7 @@ export function launch(ctx) {
   mount(win, ctx);
 }
 export function mount(winEl, ctx) {
-  const container = winEl;
+  const container = winEl.querySelector('.content');
   container.style.display = 'flex';
   container.style.flexDirection = 'column';
   container.style.gap = '4px';

--- a/src/js/apps/settings.js
+++ b/src/js/apps/settings.js
@@ -8,7 +8,7 @@ export function launch(ctx) {
   mount(win, ctx);
 }
 export async function mount(winEl, ctx) {
-  const container = winEl;
+  const container = winEl.querySelector('.content');
   container.classList.add('settings-panel');
   container.style.display = 'flex';
   container.style.flexDirection = 'column';

--- a/src/js/apps/sheets.js
+++ b/src/js/apps/sheets.js
@@ -8,7 +8,7 @@ export function launch(ctx) {
 }
 export function mount(winEl, ctx, fileData) {
   const windowManager = ctx.windowManager;
-  const container = winEl;
+  const container = winEl.querySelector('.content');
   container.style.display = 'flex';
   container.style.flexDirection = 'column';
   container.style.height = '100%';

--- a/src/js/apps/thermometer.js
+++ b/src/js/apps/thermometer.js
@@ -7,7 +7,7 @@ export function launch(ctx) {
   mount(win, ctx);
 }
 export function mount(winEl, ctx) {
-  const container = winEl;
+  const container = winEl.querySelector('.content');
   container.style.display = 'flex';
   container.style.flexDirection = 'column';
   container.style.gap = '8px';

--- a/src/js/apps/volume.js
+++ b/src/js/apps/volume.js
@@ -7,7 +7,7 @@ export function launch(ctx) {
   mount(win, ctx);
 }
 export function mount(winEl, ctx) {
-  const container = winEl;
+  const container = winEl.querySelector('.content');
   container.style.display = 'flex';
   container.style.flexDirection = 'column';
   container.style.alignItems = 'stretch';

--- a/src/js/apps/world-clock.js
+++ b/src/js/apps/world-clock.js
@@ -7,7 +7,7 @@ export function launch(ctx) {
   mount(win, ctx);
 }
 export function mount(winEl, ctx) {
-  const container = winEl;
+  const container = winEl.querySelector('.content');
   container.classList.add('file-manager');
 
   const toolbar = document.createElement('div');

--- a/src/js/core/desktop.js
+++ b/src/js/core/desktop.js
@@ -129,10 +129,15 @@ export function renderDesktopIcons(apps, launcher, profileId = "default") {
     const el = document.createElement("div");
     el.className = "desktop-icon";
     el.dataset.appId = a.id;
-    el.innerHTML = `<img alt=""><span class="label"></span>`;
+    el.innerHTML = `<img alt=""><span class=\"label\"></span>`;
     const img = el.querySelector("img");
     img.src = resolveIcon(a.icon);
     el.querySelector(".label").textContent = names[a.id] || a.title;
+    let moved = false;
+    el.addEventListener("click", (e) => {
+      if (moved || e.target.tagName === "INPUT") return;
+      launcher.launch(a.id);
+    });
     el.addEventListener("dblclick", () => launcher.launch(a.id));
 
     const pos = place(a.id);
@@ -143,6 +148,7 @@ export function renderDesktopIcons(apps, launcher, profileId = "default") {
       if (e.button !== 0 || e.target.tagName === "INPUT") return;
       e.preventDefault();
       selectIcon(el);
+      moved = false;
       const startX = e.clientX;
       const startY = e.clientY;
       const rect = el.getBoundingClientRect();
@@ -150,6 +156,7 @@ export function renderDesktopIcons(apps, launcher, profileId = "default") {
       const offY = startY - rect.top;
       el.classList.add("dragging");
       const move = (ev) => {
+        moved = true;
         el.style.left = `${ev.clientX - offX}px`;
         el.style.top = `${ev.clientY - offY}px`;
       };

--- a/src/js/core/windowManager.js
+++ b/src/js/core/windowManager.js
@@ -31,7 +31,10 @@ export class WindowManager {
       '</div>';
     const body = document.createElement("div");
     body.className = "window-body";
-    body.appendChild(contentEl);
+    const contentWrapper = document.createElement("div");
+    contentWrapper.className = "content";
+    body.appendChild(contentWrapper);
+    contentWrapper.appendChild(contentEl);
 
     win.append(header, body);
 
@@ -50,7 +53,7 @@ export class WindowManager {
       id,
       appId,
       element: win,
-      body,
+      body: contentWrapper,
       header,
       resizers,
       taskBtn: null,


### PR DESCRIPTION
## Summary
- Launch apps from desktop icons with a single click while preserving drag-and-drop and rename behaviors
- Wrap window content in a dedicated `.content` div and update window manager accordingly
- Adjust app mount functions to target the new `.content` container

## Testing
- `./run_tests.sh` *(fails: Virtual environment not found. Please run install.sh first.)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a79d8a188330941cb20308c5c3c8