### PR TITLE
refactor: remove global app references

### DIFF
--- a/src/js/apps/calculator.js
+++ b/src/js/apps/calculator.js
@@ -7,7 +7,7 @@ export function launch(ctx) {
   mount(win, ctx);
 }
 export function mount(winEl, ctx) {
-  addLog('Calculator opened');
+  ctx.globals.addLog?.('Calculator opened');
   const container = winEl.classList.contains('window')
     ? winEl.querySelector('.content')
     : winEl;

--- a/src/js/apps/crypto.js
+++ b/src/js/apps/crypto.js
@@ -79,8 +79,8 @@ export function mount(winEl, ctx) {
   controlPanel.append(addBtn, refreshBtn);
   container.append(totalPanel, holdingsPanel, controlPanel);
 
-  const portfolio = currentUser && Array.isArray(currentUser.portfolio)
-    ? [...currentUser.portfolio]
+  const portfolio = ctx.globals.currentUser && Array.isArray(ctx.globals.currentUser.portfolio)
+    ? [...ctx.globals.currentUser.portfolio]
     : [];
 
   async function fetchPrices(ids) {
@@ -118,7 +118,10 @@ export function mount(winEl, ctx) {
       removeBtn.style.cssText = 'padding:2px 6px; font-size:11px;';
       removeBtn.onclick = () => {
         portfolio.splice(idx,1);
-        if (currentUser) { currentUser.portfolio = portfolio; saveProfiles(profiles); }
+        if (ctx.globals.currentUser) {
+          ctx.globals.currentUser.portfolio = portfolio;
+          ctx.globals.saveProfiles?.(ctx.globals.profiles);
+        }
         refresh();
       };
 
@@ -145,7 +148,10 @@ export function mount(winEl, ctx) {
     const sym = id.trim().toLowerCase();
     const existing = portfolio.find(c => c.id === sym);
     if (existing) existing.amount += amount; else portfolio.push({id: sym, amount});
-    if (currentUser) { currentUser.portfolio = portfolio; saveProfiles(profiles); }
+    if (ctx.globals.currentUser) {
+      ctx.globals.currentUser.portfolio = portfolio;
+      ctx.globals.saveProfiles?.(ctx.globals.profiles);
+    }
     refresh();
   });
 

--- a/src/js/apps/gallery.js
+++ b/src/js/apps/gallery.js
@@ -7,7 +7,7 @@ export function launch(ctx) {
   mount(win, ctx);
 }
 export function mount(winEl, ctx) {
-  addLog('Gallery opened');
+  ctx.globals.addLog?.('Gallery opened');
   const container = winEl.classList.contains('window')
     ? winEl.querySelector('.content')
     : winEl;

--- a/src/js/apps/link-manager.js
+++ b/src/js/apps/link-manager.js
@@ -7,14 +7,14 @@ export function launch(ctx) {
   mount(win, ctx);
 }
 export function mount(winEl, ctx) {
-  if (!currentUser) {
+  if (!ctx.globals.currentUser) {
     const container = winEl.querySelector('.content');
     if (container) container.textContent = 'Please log in to manage links';
     return;
   }
 
-  if (!Array.isArray(currentUser.links)) currentUser.links = [];
-  currentUser.links = currentUser.links.map(item => {
+  if (!Array.isArray(ctx.globals.currentUser.links)) ctx.globals.currentUser.links = [];
+  ctx.globals.currentUser.links = ctx.globals.currentUser.links.map(item => {
     if (item.type) return item;
     return { type: 'link', name: item.name, url: item.url };
     });
@@ -34,16 +34,16 @@ export function mount(winEl, ctx) {
   container.append(toolbar, content);
 
   function getNodeByPath(path) {
-    let node = { children: currentUser.links };
+    let node = { children: ctx.globals.currentUser.links };
     path.forEach(idx => { node = node.children[idx]; });
     return node;
   }
 
   function render() {
     content.innerHTML = '';
-    const ul = buildList(currentUser.links, []);
+    const ul = buildList(ctx.globals.currentUser.links, []);
     content.append(ul);
-    saveProfiles(profiles);
+    ctx.globals.saveProfiles?.(ctx.globals.profiles);
   }
 
   function buildList(items, path) {
@@ -127,11 +127,11 @@ export function mount(winEl, ctx) {
         if (JSON.stringify(srcPath) === JSON.stringify(destPath)) return;
         const srcParent = srcPath.slice(0,-1);
         const srcIdx = srcPath[srcPath.length-1];
-        const srcContainer = srcParent.length===0 ? {children: currentUser.links} : getNodeByPath(srcParent);
+    const srcContainer = srcParent.length===0 ? {children: ctx.globals.currentUser.links} : getNodeByPath(srcParent);
         const [moved] = srcContainer.children.splice(srcIdx,1);
         const destParent = destPath.slice(0,-1);
         const destIdx = destPath[destPath.length-1];
-        const destContainer = destParent.length===0 ? {children: currentUser.links} : getNodeByPath(destParent);
+    const destContainer = destParent.length===0 ? {children: ctx.globals.currentUser.links} : getNodeByPath(destParent);
         const destNode = getNodeByPath(destPath);
         if (destNode.type === 'folder') {
           if (!destNode.children) destNode.children = [];
@@ -149,7 +149,7 @@ export function mount(winEl, ctx) {
   addFolderBtn.addEventListener('click', () => {
     const name = prompt('Folder name');
     if (!name) return;
-    currentUser.links.push({ type: 'folder', name, children: [] });
+    ctx.globals.currentUser.links.push({ type: 'folder', name, children: [] });
     render();
   });
   addLinkBtn.addEventListener('click', () => {
@@ -157,7 +157,7 @@ export function mount(winEl, ctx) {
     if (!name) return;
     const url = prompt('URL');
     if (!url) return;
-    currentUser.links.push({ type: 'link', name, url });
+    ctx.globals.currentUser.links.push({ type: 'link', name, url });
     render();
   });
 

--- a/src/js/apps/logs.js
+++ b/src/js/apps/logs.js
@@ -25,7 +25,7 @@ export function mount(winEl, ctx) {
   function render() {
     logList.innerHTML = '';
     const selected = dateSelect.value;
-    const entries = logsData[selected] || [];
+    const entries = ctx.globals.logsData[selected] || [];
     entries.forEach(entry => {
       const p = document.createElement('div');
       p.textContent = `[${entry.time}] ${entry.message}`;
@@ -35,7 +35,7 @@ export function mount(winEl, ctx) {
 
   function refreshDates() {
     dateSelect.innerHTML = '';
-    const keys = Object.keys(logsData).sort().reverse();
+    const keys = Object.keys(ctx.globals.logsData).sort().reverse();
     keys.forEach(k => {
       const opt = document.createElement('option');
       opt.value = k; opt.textContent = k; dateSelect.append(opt);
@@ -50,8 +50,8 @@ export function mount(winEl, ctx) {
 
   clearBtn.addEventListener('click', () => {
     if (confirm('Clear all logs?')) {
-      logsData = {};
-      saveLogs();
+      ctx.globals.logsData = {};
+      ctx.globals.saveLogs?.();
       refreshDates();
     }
   });

--- a/src/js/apps/media-player.js
+++ b/src/js/apps/media-player.js
@@ -7,7 +7,7 @@ export function launch(ctx) {
   mount(win, ctx);
 }
 export function mount(winEl, ctx) {
-  addLog('Media Player opened');
+  ctx.globals.addLog?.('Media Player opened');
   const container = winEl.classList.contains('window')
     ? winEl.querySelector('.content')
     : winEl;
@@ -42,14 +42,14 @@ export function mount(winEl, ctx) {
       currentEl.style.maxWidth = '100%';
       currentEl.style.maxHeight = '100%';
       currentEl.src = url;
-      addAudioElement(currentEl);
+      ctx.globals.addAudioElement?.(currentEl);
       content.append(currentEl);
       currentEl.play();
     } else if (file.type.startsWith('audio')) {
       currentEl = document.createElement('audio');
       currentEl.controls = true;
       currentEl.src = url;
-      addAudioElement(currentEl);
+      ctx.globals.addAudioElement?.(currentEl);
       content.append(currentEl);
       currentEl.play();
     } else {

--- a/src/js/apps/paint.js
+++ b/src/js/apps/paint.js
@@ -7,7 +7,7 @@ export function launch(ctx) {
   mount(win, ctx);
 }
 export function mount(winEl, ctx) {
-  addLog('Paint opened');
+  ctx.globals.addLog?.('Paint opened');
   const container = winEl.classList.contains('window')
     ? winEl.querySelector('.content')
     : winEl;

--- a/src/js/apps/recorder.js
+++ b/src/js/apps/recorder.js
@@ -64,7 +64,7 @@ export function mount(winEl, ctx) {
       const audio = document.createElement('audio');
       audio.controls = true;
       audio.src = blobUrl;
-      addAudioElement(audio);
+      ctx.globals.addAudioElement?.(audio);
       audio.play();
       ctx.windowManager.createWindow('recording', 'Recording', audio);
     }

--- a/src/js/apps/sheets.js
+++ b/src/js/apps/sheets.js
@@ -29,8 +29,8 @@ export function mount(winEl, ctx, fileData) {
     }
     return { name: name || `Sheet${sheets.length + 1}`, data: initial };
   }
-  if (!fileData && currentUser && Array.isArray(currentUser.sheets)) {
-    sheets = currentUser.sheets.map(s => ({ name: s.name, data: s.data.map(row => row.slice()) }));
+  if (!fileData && ctx.globals.currentUser && Array.isArray(ctx.globals.currentUser.sheets)) {
+    sheets = ctx.globals.currentUser.sheets.map(s => ({ name: s.name, data: s.data.map(row => row.slice()) }));
   }
   if (fileData) {
     try {
@@ -50,9 +50,9 @@ export function mount(winEl, ctx, fileData) {
   if (sheets.length === 0) sheets.push(createSheet('Sheet1'));
   let currentSheetIndex = 0;
   function persist() {
-    if (currentUser) {
-      currentUser.sheets = sheets;
-      saveProfiles(profiles);
+    if (ctx.globals.currentUser) {
+      ctx.globals.currentUser.sheets = sheets;
+      ctx.globals.saveProfiles?.(ctx.globals.profiles);
     }
   }
   persist();

--- a/src/js/apps/snip.js
+++ b/src/js/apps/snip.js
@@ -7,7 +7,7 @@ export function launch(ctx) {
 }
 
 export function mount(winEl, ctx) {
-  addLog('Snip tool activated');
+  ctx.globals.addLog?.('Snip tool activated');
   const api = new APIClient(ctx);
   const overlay = document.getElementById('snip-overlay');
   if (!overlay || overlay.style.display === 'block') return;
@@ -64,21 +64,21 @@ export function mount(winEl, ctx) {
       const blob = await new Promise(res => canvas.toBlob(res, 'image/png'));
       try {
         await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
-        showToast('Copied to clipboard');
+        ctx.globals.showToast?.('Copied to clipboard');
       } catch {
-        const path = `users/${currentUser?.id || 'guest'}/Screenshots`;
+        const path = `users/${ctx.globals.currentUser?.id || 'guest'}/Screenshots`;
         const fd = new FormData();
         fd.append('path', path);
         fd.append('file', blob, `snip-${Date.now()}.png`);
         const res = await api.post('/api/upload', fd);
         if (res.ok && res.data.ok !== false) {
-          showToast('Saved to Screenshots/');
+          ctx.globals.showToast?.('Saved to Screenshots/');
         } else {
           const a = document.createElement('a');
           a.href = URL.createObjectURL(blob);
           a.download = `screenshot-${Date.now()}.png`;
           a.click();
-          showToast('Saved screenshot');
+          ctx.globals.showToast?.('Saved screenshot');
         }
       }
     } catch (err) {

--- a/src/js/apps/terminal.js
+++ b/src/js/apps/terminal.js
@@ -39,7 +39,7 @@ export function mount(winEl, ctx) {
       return '';
     },
     theme: (name) => {
-      setTheme(name);
+      ctx.globals.setTheme?.(name);
       return `Theme changed to ${name}`;
     },
     about: () =>

--- a/src/js/apps/volume.js
+++ b/src/js/apps/volume.js
@@ -19,9 +19,9 @@ export function mount(winEl, ctx) {
   slider.min = '0';
   slider.max = '1';
   slider.step = '0.01';
-  slider.value = String(globalVolume);
+  slider.value = String(ctx.globals.globalVolume);
   slider.addEventListener('input', () => {
-    setGlobalVolume(parseFloat(slider.value));
+    ctx.globals.setGlobalVolume?.(parseFloat(slider.value));
   });
 
   container.append(label, slider);

--- a/src/js/bootstrap.js
+++ b/src/js/bootstrap.js
@@ -34,6 +34,29 @@ window.addEventListener("unhandledrejection", (e) => {
 
 export function bootstrap(){
   const ctx = {};
+  ctx.globals = {
+    get currentUser() { return window.currentUser; },
+    set currentUser(v) { window.currentUser = v; },
+    get profiles() { return window.profiles; },
+    set profiles(v) { window.profiles = v; },
+    get logsData() { return window.logsData; },
+    set logsData(v) { window.logsData = v; },
+    get globalVolume() { return window.globalVolume; },
+    set globalVolume(v) { window.globalVolume = v; },
+    saveProfiles: window.saveProfiles,
+    setTheme: window.setTheme,
+    applyUserSettings: window.applyUserSettings,
+    initContextMenu: window.initContextMenu,
+    initDesktop: window.initDesktop,
+    addLog: window.addLog,
+    saveLogs: window.saveLogs,
+    showLoginScreen: window.showLoginScreen,
+    logoutUser: window.logoutUser,
+    showToast: window.showToast,
+    addAudioElement: window.addAudioElement,
+    setGlobalVolume: window.setGlobalVolume,
+    applyChatColors: window.applyChatColors,
+  };
   console.time("registry");
   const apps = loadApps();
   console.timeEnd("registry");

--- a/src/js/core/windowManager.js
+++ b/src/js/core/windowManager.js
@@ -22,13 +22,13 @@ export class WindowManager {
 
     const header = document.createElement("div");
     header.className = "window-header";
-    header.innerHTML =
-      `<span class="title">${title}</span>` +
-      '<div class="window-controls">' +
-      '<button data-act="min" aria-label="Minimize">_</button>' +
-      '<button data-act="max" aria-label="Maximize">▢</button>' +
-      '<button data-act="close" aria-label="Close">×</button>' +
-      '</div>';
+    header.innerHTML = `
+      <span class="title">${title}</span>
+      <div class="window-controls">
+        <button data-act="min" aria-label="Minimize">_</button>
+        <button data-act="max" aria-label="Maximize">▢</button>
+        <button data-act="close" aria-label="Close">×</button>
+      </div>`;
     const body = document.createElement("div");
     body.className = "window-body";
     const contentWrapper = document.createElement("div");


### PR DESCRIPTION
## Summary
- render window control buttons with `data-act` attributes
- expose shared globals via `ctx.globals` and update apps to use them

## Testing
- `npm test` *(fails: Missing script: "test")*
- `./run_tests.sh` *(fails: Virtual environment not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ac246afc8330ad01a1fdbd9b71ca