### PR TITLE
Implement Notepad app with CodeMirror

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,10 @@
     <title>ErikOS</title>
     <link rel="icon" href="/favicon.png" type="image/png" />
     <link rel="stylesheet" href="/style.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/codemirror@5.65.16/lib/codemirror.css"
+    />
   </head>
   <body>
     <div id="desktop"></div>
@@ -42,6 +46,7 @@
       </div>
     </div>
     <div id="start-menu" role="menu" hidden><ul id="start-app-list"></ul></div>
+    <script src="https://cdn.jsdelivr.net/npm/codemirror@5.65.16/lib/codemirror.js"></script>
     <script type="module" src="/src/bootstrap/bootstrap.js"></script>
   </body>
 </html>

--- a/src/js/apps/notepad.js
+++ b/src/js/apps/notepad.js
@@ -1,5 +1,10 @@
 
-export const meta = { id: 'notepad', name: 'Notepad', icon: '/icons/notepad.png' };
+export const meta = {
+  id: "notepad",
+  name: "Notepad",
+  icon: "/icons/notepad.png",
+  comingSoon: false,
+};
 
 export function launch(ctx, initialText = "") {
   const content = document.createElement('div');
@@ -57,6 +62,8 @@ export function mount(winEl, ctx, initialText = "") {
   let currentFileHandle = null;
   let wrapEnabled = true;
 
+  wrapBtn.classList.toggle("active", wrapEnabled);
+
   function downloadFile(filename, text) {
     const blob = new Blob([text], { type: "text/plain" });
     const url = URL.createObjectURL(blob);
@@ -80,6 +87,7 @@ export function mount(winEl, ctx, initialText = "") {
     editor.setValue("");
     currentFileHandle = null;
     localStorage.removeItem(STORAGE_KEY);
+    editor.focus();
   });
 
   openBtn.addEventListener("click", async () => {
@@ -101,6 +109,7 @@ export function mount(winEl, ctx, initialText = "") {
         editor.setValue(content);
         currentFileHandle = fileHandle;
         localStorage.setItem(STORAGE_KEY, content);
+        editor.focus();
       } else {
         const input = document.createElement("input");
         input.type = "file";
@@ -113,6 +122,7 @@ export function mount(winEl, ctx, initialText = "") {
           file.text().then((text) => {
             editor.setValue(text);
             localStorage.setItem(STORAGE_KEY, text);
+            editor.focus();
           });
           currentFileHandle = null;
           input.remove();
@@ -129,6 +139,7 @@ export function mount(winEl, ctx, initialText = "") {
     const writable = await handle.createWritable();
     await writable.write(text);
     await writable.close();
+    localStorage.setItem(STORAGE_KEY, text);
     alert("File saved successfully.");
   }
 


### PR DESCRIPTION
## Summary
- implement the Notepad app UI with CodeMirror, autosave, and menu actions
- enable File System Access API usage with fallbacks for loading and saving text
- expose CodeMirror globally via CDN assets and mark Notepad as available in the registry

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ce26171fc883309bfdaa05ca2170e6