### PR TITLE
Add app error logging and enhance terminal command execution

### DIFF
--- a/.env
+++ b/.env
@@ -2,5 +2,5 @@ HOST=127.0.0.1
 PORT=8000
 ALLOWED_ORIGINS=http://localhost:*
 LOG_LEVEL=INFO
-TERMINAL_WHITELIST=ls,dir,echo,ping
+TERMINAL_WHITELIST=ls,dir,echo,ping,ollama,cat,type
 MAX_UPLOAD_MB=25

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 logs/
 *.log
 public/icons/
+DRIVE/runtime/

--- a/DRIVE/config.py
+++ b/DRIVE/config.py
@@ -58,10 +58,13 @@ class Settings:
     log_level: str = os.getenv("LOG_LEVEL", "INFO")
     terminal_whitelist: list[str] = field(
         default_factory=lambda: _split_csv(
-            os.getenv("TERMINAL_WHITELIST", "ls,dir,echo,ping,ollama")
+            os.getenv("TERMINAL_WHITELIST", "ls,dir,echo,ping,ollama,cat,type")
         )
     )
     max_upload_mb: int = int(os.getenv("MAX_UPLOAD_MB", "25"))
+    terminal_timeout_seconds: int = int(
+        os.getenv("TERMINAL_TIMEOUT_SECONDS", "5")
+    )
 
 
 settings = Settings()

--- a/src/bootstrap/bootstrap.js
+++ b/src/bootstrap/bootstrap.js
@@ -5,6 +5,7 @@ import { wireTaskbarButtons } from "../js/core/taskbar.js";
 import { buildStartMenu, wireStartToggle } from "../js/core/startMenu.js";
 import { Launcher } from "../js/core/launcher.js";
 import { WindowManager } from "../js/core/windowManager.js";
+import { logger } from "../js/utils/logger.js";
 
 function buildRegistry(mods) {
   return mods.map((m) => ({
@@ -17,6 +18,7 @@ function buildRegistry(mods) {
 
 async function main() {
   const ctx = { profileId: localStorage.getItem("profileId") || "default" };
+  ctx.logger = logger;
   const wm = new WindowManager();
   ctx.windowManager = wm;
 

--- a/src/js/apps/diagnostics.js
+++ b/src/js/apps/diagnostics.js
@@ -26,10 +26,58 @@ export function mount(winEl, ctx) {
           li.textContent = iss;
           list.append(li);
         });
-        container.append('Issues detected:', list);
+        const issuesHeading = document.createElement('h3');
+        issuesHeading.textContent = 'Issues detected';
+        issuesHeading.style.marginTop = '0';
+        container.append(issuesHeading, list);
       } else {
-        container.textContent = 'All checks passed';
+        const ok = document.createElement('p');
+        ok.textContent = 'All checks passed';
+        ok.style.marginTop = '0';
+        container.append(ok);
       }
+
+      const errors = Array.isArray(data.errors) ? data.errors : [];
+      const errorSection = document.createElement('section');
+      errorSection.style.marginTop = '16px';
+      const errorHeading = document.createElement('h3');
+      errorHeading.textContent = 'Recent app errors';
+      errorHeading.style.marginBottom = '8px';
+      errorSection.append(errorHeading);
+
+      if (errors.length === 0) {
+        const empty = document.createElement('p');
+        empty.textContent = 'No recent client errors logged.';
+        errorSection.append(empty);
+      } else {
+        const list = document.createElement('ul');
+        list.style.listStyle = 'none';
+        list.style.padding = '0';
+        errors.forEach(err => {
+          const item = document.createElement('li');
+          item.style.marginBottom = '12px';
+          const header = document.createElement('strong');
+          const appName = err.app || 'unknown';
+          header.textContent = `[${err.timestamp}] ${appName}: ${err.message}`;
+          item.append(header);
+          if (err.stack) {
+            const pre = document.createElement('pre');
+            pre.textContent = err.stack;
+            pre.style.whiteSpace = 'pre-wrap';
+            pre.style.margin = '4px 0 0';
+            pre.style.padding = '6px';
+            pre.style.background = 'var(--window-border-dark, #1b1b1b)';
+            pre.style.borderRadius = '4px';
+            pre.style.maxHeight = '160px';
+            pre.style.overflow = 'auto';
+            item.append(pre);
+          }
+          list.append(item);
+        });
+        errorSection.append(list);
+      }
+
+      container.append(errorSection);
     })
     .catch(err => {
       container.textContent = 'Diagnostics failed: ' + err;

--- a/src/js/core/launcher.js
+++ b/src/js/core/launcher.js
@@ -1,4 +1,5 @@
 import { WindowManager } from "./windowManager.js";
+import { logger as defaultLogger } from "../utils/logger.js";
 
 export class Launcher {
   constructor(ctx, registry) {
@@ -6,6 +7,8 @@ export class Launcher {
     this.registry = registry;
     this.wm = ctx.windowManager || new WindowManager();
     this.ctx.windowManager = this.wm;
+    this.logger = this.ctx.logger || defaultLogger;
+    this.ctx.logger = this.logger;
   }
 
   async launch(id) {
@@ -14,29 +17,161 @@ export class Launcher {
       console.warn("Unknown app", id);
       return;
     }
+    let mod;
     try {
-      const mod = await import(`../apps/${id}.js`);
-      if (typeof mod.launch === "function") {
-        mod.launch(this.ctx);
-        return;
-      }
-      const meta = mod.meta || {
+      mod = await import(`../apps/${id}.js`);
+    } catch (error) {
+      const meta = {
         id: app.id,
         name: app.title,
         icon: app.icon,
       };
-      if (typeof mod.mount === "function") {
-        const content = document.createElement("div");
-        const winId = this.wm.createWindow(meta.id, meta.name, content);
-        const winInfo = this.wm.windows.get(winId);
-        mod.mount(winInfo?.element || content, this.ctx);
-      } else if (typeof mod.default === "function") {
-        mod.default(this.ctx);
-      } else {
-        console.warn(`App ${id} has no entry point`);
+      this._renderError(meta, error);
+      return;
+    }
+
+    const meta = {
+      id: mod.meta?.id || app.id,
+      name: mod.meta?.name || app.title,
+      icon: mod.meta?.icon || app.icon,
+    };
+
+    if (typeof mod.launch === "function") {
+      try {
+        await Promise.resolve(mod.launch(this.ctx));
+      } catch (error) {
+        this._renderError(meta, error);
       }
-    } catch (err) {
-      console.error("Failed to launch", id, err);
+      return;
+    }
+
+    if (typeof mod.mount === "function") {
+      const content = document.createElement("div");
+      let winId;
+      let winInfo;
+      try {
+        winId = this.wm.createWindow(meta.id, meta.name, content);
+        winInfo = this.wm.windows.get(winId);
+        await Promise.resolve(mod.mount(winInfo?.element || content, this.ctx));
+      } catch (error) {
+        if (!winInfo && winId) {
+          winInfo = this.wm.windows.get(winId);
+        }
+        this._renderError(meta, error, winInfo);
+      }
+      return;
+    }
+
+    if (typeof mod.default === "function") {
+      try {
+        await Promise.resolve(mod.default(this.ctx));
+      } catch (error) {
+        this._renderError(meta, error);
+      }
+      return;
+    }
+
+    console.warn(`App ${id} has no entry point`);
+  }
+
+  _renderError(meta, error, winInfo) {
+    const message = error?.message || String(error);
+    const stack = error?.stack || (error ? String(error) : "");
+    this.logger.error({ app: meta.id, message, stack });
+
+    const panel = document.createElement("div");
+    panel.className = "app-error-panel";
+    panel.style.padding = "16px";
+    panel.style.display = "flex";
+    panel.style.flexDirection = "column";
+    panel.style.gap = "12px";
+
+    const title = document.createElement("h2");
+    title.textContent = `${meta.name} ran into a problem`;
+    title.style.margin = "0";
+    panel.append(title);
+
+    const summary = document.createElement("p");
+    summary.textContent = message;
+    summary.style.margin = "0";
+    summary.style.fontWeight = "600";
+    panel.append(summary);
+
+    const pre = document.createElement("pre");
+    pre.textContent = stack;
+    pre.style.whiteSpace = "pre-wrap";
+    pre.style.background = "var(--window-border-dark, #1b1b1b)";
+    pre.style.color = "inherit";
+    pre.style.padding = "8px";
+    pre.style.borderRadius = "4px";
+    pre.style.maxHeight = "200px";
+    pre.style.overflow = "auto";
+    panel.append(pre);
+
+    const actions = document.createElement("div");
+    actions.style.display = "flex";
+    actions.style.gap = "8px";
+
+    const copyBtn = document.createElement("button");
+    copyBtn.textContent = "Copy logs";
+    copyBtn.addEventListener("click", async () => {
+      const payload = this.logger.formatRecentErrors(50) || `${message}\n${stack}`;
+      try {
+        if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(payload);
+        } else {
+          const textarea = document.createElement("textarea");
+          textarea.value = payload;
+          textarea.setAttribute("readonly", "true");
+          textarea.style.position = "absolute";
+          textarea.style.left = "-9999px";
+          document.body.appendChild(textarea);
+          textarea.select();
+          document.execCommand("copy");
+          textarea.remove();
+        }
+        copyBtn.textContent = "Copied";
+        setTimeout(() => {
+          copyBtn.textContent = "Copy logs";
+        }, 2000);
+      } catch (_) {
+        copyBtn.textContent = "Copy failed";
+        setTimeout(() => {
+          copyBtn.textContent = "Copy logs";
+        }, 2000);
+      }
+    });
+    actions.append(copyBtn);
+
+    const reopenBtn = document.createElement("button");
+    reopenBtn.textContent = "Reopen";
+    let targetId = winInfo?.id;
+    reopenBtn.addEventListener("click", () => {
+      if (targetId) {
+        this.wm.closeWindow(targetId);
+      }
+      this.launch(meta.id);
+    });
+    actions.append(reopenBtn);
+
+    panel.append(actions);
+
+    if (!winInfo) {
+      const container = document.createElement("div");
+      const winId = this.wm.createWindow(meta.id, `${meta.name} (error)`, container);
+      winInfo = this.wm.windows.get(winId);
+      targetId = winInfo?.id || winId;
+    }
+
+    if (winInfo?.body) {
+      winInfo.body.innerHTML = "";
+      winInfo.body.append(panel);
+    } else if (winInfo?.element) {
+      const content = winInfo.element.querySelector(".content");
+      if (content) {
+        content.innerHTML = "";
+        content.append(panel);
+      }
     }
   }
 }

--- a/src/js/utils/logger.js
+++ b/src/js/utils/logger.js
@@ -1,0 +1,61 @@
+const MAX_LOG_ENTRIES = 500;
+const ERROR_ENDPOINT = '/api/log-client-error';
+
+const errorLog = [];
+
+function normaliseEntry(payload = {}) {
+  const now = new Date();
+  const entry = {
+    timestamp: payload.timestamp || now.toISOString(),
+    app: payload.app || 'unknown',
+    message: payload.message || 'Unknown error',
+    stack: payload.stack || '',
+  };
+  return entry;
+}
+
+function persistEntry(entry) {
+  try {
+    const body = JSON.stringify(entry);
+    if (typeof navigator !== 'undefined' && navigator.sendBeacon) {
+      const blob = new Blob([body], { type: 'application/json' });
+      navigator.sendBeacon(ERROR_ENDPOINT, blob);
+    } else if (typeof fetch !== 'undefined') {
+      fetch(ERROR_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+        keepalive: true,
+      }).catch(() => {});
+    }
+  } catch (err) {
+    console.warn('Failed to persist error log', err);
+  }
+}
+
+export const logger = {
+  error(payload) {
+    const entry = normaliseEntry(payload);
+    errorLog.push(entry);
+    if (errorLog.length > MAX_LOG_ENTRIES) {
+      errorLog.splice(0, errorLog.length - MAX_LOG_ENTRIES);
+    }
+    try {
+      window.__ERIKOS_ERROR_LOG__ = [...errorLog];
+    } catch (_) {
+      /* ignore */
+    }
+    persistEntry(entry);
+    console.error('App error', entry);
+  },
+  getRecentErrors(limit = 50) {
+    if (limit <= 0) return [];
+    return errorLog.slice(-limit).map((item) => ({ ...item }));
+  },
+  formatRecentErrors(limit = 50) {
+    const items = this.getRecentErrors(limit);
+    return items
+      .map((item) => `[${item.timestamp}] ${item.app}: ${item.message}\n${item.stack}`)
+      .join('\n\n');
+  },
+};

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -85,3 +85,17 @@ def test_diagnostics_missing_icon():
         "Missing icon file: /icons/does-not-exist.png" in issue
         for issue in result.get("issues", [])
     )
+
+
+def test_log_client_error_endpoint(client):
+    payload = {"app": "tester", "message": "boom", "stack": "trace"}
+    resp = client.post("/api/log-client-error", json=payload)
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data.get("ok") is True
+
+    resp = client.get("/api/diagnostics/run")
+    assert resp.status_code == 200
+    diag = resp.get_json()
+    assert "errors" in diag
+    assert any(err.get("app") == "tester" for err in diag.get("errors", []))

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -1,0 +1,80 @@
+import time
+
+import pytest
+
+from DRIVE.app import app
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
+
+
+def _wait_for_job(client, job_id):
+    for _ in range(50):
+        resp = client.get(f"/api/command-status/{job_id}")
+        data = resp.get_json()
+        if data.get("status") == "finished":
+            return data
+        time.sleep(0.05)
+    raise AssertionError("command did not finish in time")
+
+
+@pytest.mark.skipif(app.config.get("ENV") == "production", reason="not needed")
+def test_linux_commands_execute(client, monkeypatch):
+    monkeypatch.setattr("DRIVE.app._is_windows", lambda: False)
+    resp = client.post("/api/execute-command", json={"command": "ls"})
+    assert resp.status_code == 200
+    job = _wait_for_job(client, resp.get_json()["job_id"])
+    assert job["returncode"] == 0
+
+    resp = client.post("/api/execute-command", json={"command": "cat README.md"})
+    assert resp.status_code == 200
+    job = _wait_for_job(client, resp.get_json()["job_id"])
+    assert job["returncode"] == 0
+    assert job["output"].strip()
+
+
+def test_windows_builtins_use_cmd(monkeypatch, client):
+    outputs = {"calls": []}
+
+    class DummyProc:
+        def __init__(self, args, stdout=None, stderr=None, text=None, shell=None):
+            outputs["calls"].append({"args": args, "shell": shell})
+            self.returncode = 0
+
+        def communicate(self, timeout=None):
+            return ("ok", "")
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr("DRIVE.app._is_windows", lambda: True)
+    monkeypatch.setattr("DRIVE.app.subprocess.Popen", DummyProc)
+
+    for command in ["dir", "echo hello", "type LICENSE"]:
+        outputs["calls"].clear()
+        resp = client.post("/api/execute-command", json={"command": command})
+        assert resp.status_code == 200
+        job = _wait_for_job(client, resp.get_json()["job_id"])
+        assert job["returncode"] == 0
+        assert outputs["calls"]
+        call = outputs["calls"][0]
+        assert call["args"] == ["cmd", "/c", command]
+        assert call["shell"] is True
+
+
+def test_command_too_long(client):
+    long_cmd = "a" * 2100
+    resp = client.post("/api/execute-command", json={"command": long_cmd})
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data["error"] == "Command too long"
+
+
+def test_command_rejects_operators(client):
+    resp = client.post("/api/execute-command", json={"command": "ls && whoami"})
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "Command contains unsupported operators"


### PR DESCRIPTION
## Summary
- add a front-end logger utility and wire the launcher to show an inline crash panel with copy/reopen actions
- persist client-side errors on the backend, expose the latest entries through diagnostics, and render them in the Diagnostics app
- harden command execution with length/operator guards, Windows cmd support, configurable timeout, and new cross-platform terminal tests

## Testing
- npm test
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce449e44fc833091e8c3056e69d571