### PR TITLE
Implement enhanced Notepad and file management UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
   "scripts": {
-    "test": "node tools/verify-app-registry.js && node tests/test_frontend.js && node tests/windowManager.test.js"
+    "test": "node tools/verify-app-registry.js && node tests/test_frontend.js && node tests/windowManager.test.js && node tests/notepad.test.js"
   }
 }

--- a/src/js/apps/media-player.js
+++ b/src/js/apps/media-player.js
@@ -1,4 +1,6 @@
 
+import { pickOpen } from '../utils/file-dialogs.js';
+
 export const meta = { id: 'media-player', name: 'Media Player', icon: '/icons/media-player.png' };
 export function launch(ctx) {
   const content = document.createElement('div');
@@ -61,34 +63,32 @@ export function mount(winEl, ctx) {
 
   openBtn.addEventListener('click', async () => {
     try {
-      if (window.showOpenFilePicker) {
-        const [handle] = await window.showOpenFilePicker({
-          types: [
-            {
-              description: 'Media',
-              accept: {
-                'audio/*': ['.mp3', '.wav', '.ogg'],
-                'video/*': ['.mp4', '.webm', '.ogg'],
+      const selection = await (ctx?.fileDialogs?.pickOpen
+        ? ctx.fileDialogs.pickOpen({
+            types: [
+              {
+                description: 'Media',
+                accept: {
+                  'audio/*': ['.mp3', '.wav', '.ogg'],
+                  'video/*': ['.mp4', '.webm', '.ogg'],
+                },
               },
-            },
-          ],
-          multiple: false,
-        });
-        const file = await handle.getFile();
-        await loadFile(file);
-      } else {
-        const input = document.createElement('input');
-        input.type = 'file';
-        input.accept = 'audio/*,video/*';
-        input.style.display = 'none';
-        document.body.append(input);
-        input.addEventListener('change', () => {
-          const file = input.files[0];
-          loadFile(file);
-          input.remove();
-        });
-        input.click();
-      }
+            ],
+          })
+        : pickOpen({
+            types: [
+              {
+                description: 'Media',
+                accept: {
+                  'audio/*': ['.mp3', '.wav', '.ogg'],
+                  'video/*': ['.mp4', '.webm', '.ogg'],
+                },
+              },
+            ],
+          }));
+      const entry = Array.isArray(selection) ? selection[0] : selection;
+      if (!entry) return;
+      await loadFile(entry.file);
     } catch (err) {
       console.error(err);
     }

--- a/src/js/apps/notepad.js
+++ b/src/js/apps/notepad.js
@@ -1,196 +1,384 @@
+import { pickOpen, pickSave } from '../utils/file-dialogs.js';
 
 export const meta = {
-  id: "notepad",
-  name: "Notepad",
-  icon: "/icons/notepad.png",
+  id: 'notepad',
+  name: 'Notepad',
+  icon: '/icons/notepad.png',
   comingSoon: false,
 };
 
-export function launch(ctx, initialText = "") {
-  const content = document.createElement('div');
-  const id = ctx.windowManager.createWindow(meta.id, meta.name, content);
-  const win = ctx.windowManager.windows.get(id).element;
-  mount(win, ctx, initialText);
+const AUTOSAVE_KEY = 'notepad-autosave';
+const LAST_PATH_KEY = 'notepad-last-path';
+const TEXT_TYPES = [
+  {
+    description: 'Text files',
+    accept: {
+      'text/plain': ['.txt', '.md', '.csv', '.json', '.js', '.html', '.css'],
+    },
+  },
+];
+
+let codeMirrorPromise = null;
+
+function ensureCodeMirror() {
+  if (!codeMirrorPromise) {
+    codeMirrorPromise = import('https://esm.sh/codemirror@5.65.16?bundle');
+  }
+  return codeMirrorPromise.then((mod) => mod.default || mod);
 }
 
-export function mount(winEl, ctx, initialText = "") {
+function getTitleElement(winEl) {
+  return winEl.querySelector('.window-header .title');
+}
+
+function setWindowTitle(winEl, name, dirty) {
+  const titleEl = getTitleElement(winEl);
+  if (titleEl) titleEl.textContent = `${dirty ? '* ' : ''}${meta.name} - ${name}`;
+}
+
+function updateStatusBar(statusEl, cursor, dirty, infoText = '') {
+  const line = cursor?.line ?? 0;
+  const ch = cursor?.ch ?? 0;
+  const parts = [`Ln ${line + 1}`, `Col ${ch + 1}`];
+  if (infoText) parts.push(infoText);
+  if (dirty) parts.push('Unsaved');
+  statusEl.textContent = parts.join(' · ');
+}
+
+async function ensurePermission(handle, mode = 'read') {
+  if (!handle || typeof handle.queryPermission !== 'function') return true;
+  try {
+    const opts = { mode };
+    let status = await handle.queryPermission(opts);
+    if (status === 'granted') return true;
+    if (status === 'prompt' && typeof handle.requestPermission === 'function') {
+      status = await handle.requestPermission(opts);
+      return status === 'granted';
+    }
+    return status === 'granted';
+  } catch (err) {
+    console.warn('Permission request failed', err);
+    return false;
+  }
+}
+
+async function writeToHandle(handle, contents) {
+  const writable = await handle.createWritable();
+  await writable.write(contents);
+  await writable.close();
+}
+
+export async function launch(ctx, initial = '') {
+  const content = document.createElement('div');
+  const id = ctx.windowManager.createWindow(meta.id, meta.name, content);
+  const win = ctx.windowManager.windows.get(id)?.element;
+  if (!win) return;
+  await mount(win, ctx, initial);
+}
+
+export async function mount(winEl, ctx, initial = '') {
   const container = winEl.querySelector('.content');
-  container.style.display = "flex";
-  container.style.flexDirection = "column";
-  container.style.height = "100%";
+  if (!container) return null;
+  container.innerHTML = '';
+  container.classList.add('notepad');
 
-  const STORAGE_KEY = "notepad-autosave";
+  const dialogs = {
+    pickOpen: ctx?.fileDialogs?.pickOpen ?? pickOpen,
+    pickSave: ctx?.fileDialogs?.pickSave ?? pickSave,
+  };
+  const loadCodeMirror = ctx?.codeMirrorLoader ?? ensureCodeMirror;
 
-  const menu = document.createElement("div");
-  menu.classList.add("notepad-menu");
+  const layout = document.createElement('div');
+  layout.classList.add('notepad-layout');
 
-  function makeBtn(label, title) {
-    const btn = document.createElement("button");
+  const menu = document.createElement('div');
+  menu.classList.add('notepad-menu');
+
+  const editorHost = document.createElement('div');
+  editorHost.classList.add('notepad-editor-host');
+
+  const status = document.createElement('div');
+  status.classList.add('notepad-status');
+  status.textContent = 'Ln 1 · Col 1';
+
+  layout.append(menu, editorHost, status);
+  container.append(layout);
+
+  function makeButton(label, title, options = {}) {
+    const btn = document.createElement('button');
     btn.textContent = label;
     if (title) btn.title = title;
+    if (options.toggle) btn.dataset.toggle = '1';
     return btn;
   }
 
-  const newBtn = makeBtn("New", "New file");
-  const openBtn = makeBtn("Open", "Open file");
-  const saveBtn = makeBtn("Save", "Save file");
-  const saveAsBtn = makeBtn("Save As", "Save as");
-  const wrapBtn = makeBtn("Wrap", "Toggle word wrap");
-  const undoBtn = makeBtn("Undo", "Undo");
-  const redoBtn = makeBtn("Redo", "Redo");
+  const newBtn = makeButton('New', 'Create a new document');
+  const openBtn = makeButton('Open', 'Open an existing file');
+  const saveBtn = makeButton('Save', 'Save changes');
+  const saveAsBtn = makeButton('Save As', 'Save with a new name');
+  const wrapBtn = makeButton('Wrap', 'Toggle word wrap', { toggle: true });
+  const undoBtn = makeButton('Undo', 'Undo last change');
+  const redoBtn = makeButton('Redo', 'Redo last change');
+
   menu.append(newBtn, openBtn, saveBtn, saveAsBtn, wrapBtn, undoBtn, redoBtn);
-  container.append(menu);
 
-  const textarea = document.createElement("textarea");
-  textarea.classList.add("notepad-editor");
-  textarea.value = initialText || localStorage.getItem(STORAGE_KEY) || "";
-  container.append(textarea);
+  const textarea = document.createElement('textarea');
+  textarea.classList.add('notepad-textarea');
+  editorHost.append(textarea);
 
+  const CodeMirror = await loadCodeMirror();
   const editor = CodeMirror.fromTextArea(textarea, {
     lineNumbers: true,
-    mode: "text/plain",
+    mode: 'text/plain',
     lineWrapping: true,
-    tabSize: 4,
-    indentUnit: 4,
-    indentWithTabs: true,
-    smartIndent: true,
+    tabSize: 2,
+    indentUnit: 2,
   });
 
-  winEl.addEventListener("resized", () => editor.refresh());
+  editor.setSize('100%', '100%');
   setTimeout(() => editor.refresh(), 0);
 
-  let currentFileHandle = null;
+  let currentHandle = null;
+  let currentName = 'untitled.txt';
+  let currentPathInfo = '';
+  let dirty = false;
   let wrapEnabled = true;
+  let autosaveTimer = null;
 
-  wrapBtn.classList.toggle("active", wrapEnabled);
+  const storedPathInfo = (() => {
+    try {
+      return localStorage.getItem(LAST_PATH_KEY) || '';
+    } catch (_) {
+      return '';
+    }
+  })();
 
-  function downloadFile(filename, text) {
-    const blob = new Blob([text], { type: "text/plain" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = filename;
-    document.body.append(a);
-    a.click();
-    a.remove();
-    URL.revokeObjectURL(url);
+  const storedText = (() => {
+    try {
+      return localStorage.getItem(AUTOSAVE_KEY);
+    } catch (_) {
+      return null;
+    }
+  })();
+
+  const initialState = normalizeInitial(initial, storedText);
+  if (initialState.name) currentName = initialState.name;
+  if (initialState.path) currentPathInfo = initialState.path;
+  else if (initialState.handle?.name) currentPathInfo = initialState.handle.name;
+  else if (storedPathInfo) currentPathInfo = storedPathInfo;
+  if (initialState.handle) currentHandle = initialState.handle;
+
+  editor.setValue(initialState.content);
+  setWindowTitle(winEl, currentName, dirty);
+  updateStatusBar(status, editor.getCursor(), dirty, currentPathInfo);
+  wrapBtn.classList.toggle('active', wrapEnabled);
+
+  function persistAutosave(text) {
+    try {
+      localStorage.setItem(AUTOSAVE_KEY, text);
+    } catch (_) {
+      /* ignore */
+    }
   }
 
-  editor.on("change", () => {
+  function persistPath(path) {
     try {
-      localStorage.setItem(STORAGE_KEY, editor.getValue());
-    } catch {}
-  });
+      if (path) localStorage.setItem(LAST_PATH_KEY, path);
+      else localStorage.removeItem(LAST_PATH_KEY);
+    } catch (_) {
+      /* ignore */
+    }
+  }
 
-  newBtn.addEventListener("click", () => {
-    if (!confirm("Discard current document?")) return;
-    editor.setValue("");
-    currentFileHandle = null;
-    localStorage.removeItem(STORAGE_KEY);
+  function markDirty(value) {
+    dirty = value;
+    setWindowTitle(winEl, currentName, dirty);
+    updateStatusBar(status, editor.getCursor(), dirty, currentPathInfo);
+  }
+
+  function setContent(content, options = {}) {
+    editor.setValue(content ?? '');
     editor.focus();
-  });
-
-  openBtn.addEventListener("click", async () => {
-    try {
-      if (window.showOpenFilePicker) {
-        const [fileHandle] = await window.showOpenFilePicker({
-          types: [
-            {
-              description: "Text files",
-              accept: {
-                "text/plain": [".txt", ".md", ".csv", ".js", ".html", ".css"],
-              },
-            },
-          ],
-          multiple: false,
-        });
-        const file = await fileHandle.getFile();
-        const content = await file.text();
-        editor.setValue(content);
-        currentFileHandle = fileHandle;
-        localStorage.setItem(STORAGE_KEY, content);
-        editor.focus();
-      } else {
-        const input = document.createElement("input");
-        input.type = "file";
-        input.accept = ".txt,.md,.csv,.js,.html,.css";
-        input.style.display = "none";
-        document.body.append(input);
-        input.addEventListener("change", () => {
-          const file = input.files[0];
-          if (!file) return;
-          file.text().then((text) => {
-            editor.setValue(text);
-            localStorage.setItem(STORAGE_KEY, text);
-            editor.focus();
-          });
-          currentFileHandle = null;
-          input.remove();
-        });
-        input.click();
-      }
-    } catch (err) {
-      console.error(err);
-    }
-  });
-
-  async function saveToHandle(handle) {
-    const text = editor.getValue();
-    const writable = await handle.createWritable();
-    await writable.write(text);
-    await writable.close();
-    localStorage.setItem(STORAGE_KEY, text);
-    alert("File saved successfully.");
+    markDirty(Boolean(options.dirty));
+    if (!options.dirty) persistAutosave(editor.getValue());
   }
 
-  saveBtn.addEventListener("click", async () => {
-    const text = editor.getValue();
-    try {
-      if (currentFileHandle) {
-        await saveToHandle(currentFileHandle);
-      } else if (window.showSaveFilePicker) {
-        const fileHandle = await window.showSaveFilePicker({
-          suggestedName: "untitled.txt",
-          types: [
-            { description: "Text files", accept: { "text/plain": [".txt"] } },
-          ],
-        });
-        await saveToHandle(fileHandle);
-        currentFileHandle = fileHandle;
-      } else {
-        downloadFile("untitled.txt", text);
-      }
-    } catch (err) {
-      console.error(err);
-    }
+  function applyHandle(handle, name, path) {
+    currentHandle = handle ?? null;
+    currentName = name || handle?.name || 'untitled.txt';
+    currentPathInfo = path || handle?.name || '';
+    persistPath(currentPathInfo);
+    setWindowTitle(winEl, currentName, dirty);
+    updateStatusBar(status, editor.getCursor(), dirty, currentPathInfo);
+  }
+
+  function editorChanged() {
+    persistAutosave(editor.getValue());
+    markDirty(true);
+  }
+
+  editor.on('change', editorChanged);
+  editor.on('cursorActivity', () => {
+    updateStatusBar(status, editor.getCursor(), dirty, currentPathInfo);
   });
 
-  saveAsBtn.addEventListener("click", async () => {
+  winEl.addEventListener('resized', () => editor.refresh());
+
+  async function openFile() {
+    try {
+      const selection = await dialogs.pickOpen({ types: TEXT_TYPES, multiple: false });
+      if (!selection) return;
+      const { file, handle } = selection;
+      const text = await file.text();
+      applyHandle(handle, file.name);
+      setContent(text, { dirty: false });
+    } catch (err) {
+      console.error('Failed to open file', err);
+    }
+  }
+
+  async function saveFile({ forcePrompt = false } = {}) {
     const text = editor.getValue();
     try {
-      if (window.showSaveFilePicker) {
-        const fileHandle = await window.showSaveFilePicker({
-          suggestedName: "untitled.txt",
-          types: [
-            { description: "Text files", accept: { "text/plain": [".txt"] } },
-          ],
-        });
-        await saveToHandle(fileHandle);
-        currentFileHandle = fileHandle;
-      } else {
-        downloadFile("untitled.txt", text);
+      if (currentHandle && !forcePrompt) {
+        if (await ensurePermission(currentHandle, 'readwrite')) {
+          await writeToHandle(currentHandle, text);
+          markDirty(false);
+          persistAutosave(text);
+          return true;
+        }
       }
+      const picker = await dialogs.pickSave({ suggestedName: currentName, types: TEXT_TYPES });
+      await picker.write(text, 'text/plain');
+      if (picker.handle) {
+        applyHandle(picker.handle, picker.handle.name);
+      }
+      markDirty(false);
+      persistAutosave(text);
+      return true;
     } catch (err) {
-      console.error(err);
+      console.error('Failed to save file', err);
+      return false;
     }
-  });
+  }
 
-  wrapBtn.addEventListener("click", () => {
+  async function saveFileAs() {
+    return saveFile({ forcePrompt: true });
+  }
+
+  function newDocument() {
+    if (dirty && !confirm('Discard unsaved changes?')) return;
+    applyHandle(null, 'untitled.txt', '');
+    setContent('', { dirty: false });
+    persistPath('');
+  }
+
+  function toggleWrap() {
     wrapEnabled = !wrapEnabled;
-    editor.setOption("lineWrapping", wrapEnabled);
-    wrapBtn.classList.toggle("active", wrapEnabled);
-  });
+    editor.setOption('lineWrapping', wrapEnabled);
+    wrapBtn.classList.toggle('active', wrapEnabled);
+  }
 
-  undoBtn.addEventListener("click", () => editor.undo && editor.undo());
-  redoBtn.addEventListener("click", () => editor.redo && editor.redo());
+  function bindShortcut(e) {
+    if (!e.ctrlKey) return;
+    switch (e.key.toLowerCase()) {
+      case 'n':
+        e.preventDefault();
+        newDocument();
+        break;
+      case 'o':
+        e.preventDefault();
+        openFile();
+        break;
+      case 's':
+        e.preventDefault();
+        saveFile({ forcePrompt: e.shiftKey });
+        break;
+      default:
+        break;
+    }
+  }
+
+  function autosaveTick() {
+    if (!dirty) return;
+    const text = editor.getValue();
+    if (currentHandle) {
+      ensurePermission(currentHandle, 'readwrite')
+        .then((granted) => granted && writeToHandle(currentHandle, text))
+        .then((result) => {
+          if (result !== false) {
+            markDirty(false);
+            persistAutosave(text);
+          }
+        })
+        .catch((err) => console.warn('Autosave failed', err));
+    } else {
+      persistAutosave(text);
+    }
+  }
+
+  newBtn.addEventListener('click', newDocument);
+  openBtn.addEventListener('click', openFile);
+  saveBtn.addEventListener('click', () => saveFile());
+  saveAsBtn.addEventListener('click', () => saveFileAs());
+  wrapBtn.addEventListener('click', toggleWrap);
+  undoBtn.addEventListener('click', () => editor.undo?.());
+  redoBtn.addEventListener('click', () => editor.redo?.());
+  winEl.addEventListener('keydown', bindShortcut);
+
+  autosaveTimer = setInterval(autosaveTick, 20000);
+
+  const beforeClose = (ev) => {
+    if (!dirty) return;
+    const ok = window.confirm('You have unsaved changes. Close anyway?');
+    if (!ok) ev.preventDefault();
+  };
+  winEl.addEventListener('window-before-close', beforeClose);
+
+  const cleanup = () => {
+    if (autosaveTimer) clearInterval(autosaveTimer);
+    winEl.removeEventListener('window-before-close', beforeClose);
+    winEl.removeEventListener('keydown', bindShortcut);
+    editor.off?.('change', editorChanged);
+  };
+  winEl.addEventListener('window-closed', cleanup, { once: true });
+
+  const api = {
+    editor,
+    get value() {
+      return editor.getValue();
+    },
+    setValue(text) {
+      editor.setValue(text);
+    },
+    isDirty: () => dirty,
+    save: saveFile,
+    saveAs: saveFileAs,
+    newDocument,
+    applyHandle,
+    dispose: cleanup,
+  };
+  winEl.__notepad = api;
+  return api;
+}
+
+function normalizeInitial(initial, autosaved) {
+  if (!initial) {
+    return {
+      content: autosaved || '',
+      name: 'untitled.txt',
+    };
+  }
+  if (typeof initial === 'string') {
+    return {
+      content: initial || autosaved || '',
+      name: 'untitled.txt',
+    };
+  }
+  return {
+    content: initial.content ?? autosaved ?? '',
+    name: initial.name || initial.title || 'untitled.txt',
+    path: initial.path || initial.filePath || '',
+    handle: initial.handle || null,
+  };
 }

--- a/src/js/core/windowManager.js
+++ b/src/js/core/windowManager.js
@@ -224,7 +224,23 @@ export class WindowManager {
   closeWindow(id) {
     const info = this.windows.get(id);
     if (!info) return;
+    const detail = { id, appId: info.appId, element: info.element };
+    const localEvent = new CustomEvent("window-before-close", {
+      detail,
+      cancelable: true,
+    });
+    info.element.dispatchEvent(localEvent);
+    if (localEvent.defaultPrevented) return;
+
+    const globalBefore = new CustomEvent("window-before-close", {
+      detail,
+      cancelable: true,
+    });
+    window.dispatchEvent(globalBefore);
+    if (globalBefore.defaultPrevented) return;
+
     const wasActive = this.activeId === id;
+    info.element.dispatchEvent(new CustomEvent("window-closed", { detail }));
     info.element.remove();
     info.taskBtn?.remove();
     this.windows.delete(id);
@@ -234,6 +250,7 @@ export class WindowManager {
         new CustomEvent("window-blurred", { detail: { id } }),
       );
     }
+    window.dispatchEvent(new CustomEvent("window-closed", { detail }));
   }
 
   _saveBounds(info) {

--- a/src/js/utils/file-dialogs.js
+++ b/src/js/utils/file-dialogs.js
@@ -1,0 +1,116 @@
+const supportsFileSystemAccess = () =>
+  typeof window !== 'undefined' && !!window.showOpenFilePicker;
+
+function buildAcceptString(types = []) {
+  if (!Array.isArray(types) || types.length === 0) return '';
+  const values = new Set();
+  for (const type of types) {
+    if (!type || !type.accept) continue;
+    for (const [mime, extensions] of Object.entries(type.accept)) {
+      if (mime && mime !== '*/*') values.add(mime);
+      if (Array.isArray(extensions)) {
+        for (const ext of extensions) {
+          if (ext) values.add(ext);
+        }
+      }
+    }
+  }
+  return Array.from(values).join(',');
+}
+
+export async function pickOpen({ types = [], multiple = false } = {}) {
+  if (supportsFileSystemAccess()) {
+    try {
+      const handles = await window.showOpenFilePicker({ types, multiple });
+      const entries = await Promise.all(
+        handles.map(async (handle) => ({
+          handle,
+          file: await handle.getFile(),
+        })),
+      );
+      return multiple ? entries : entries[0] ?? null;
+    } catch (err) {
+      if (err?.name === 'AbortError') return multiple ? [] : null;
+      throw err;
+    }
+  }
+
+  const accept = buildAcceptString(types);
+  return await new Promise((resolve) => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.multiple = Boolean(multiple);
+    if (accept) input.accept = accept;
+    input.style.position = 'fixed';
+    input.style.left = '-10000px';
+    input.style.top = '0';
+    input.addEventListener('change', () => {
+      const files = Array.from(input.files || []).map((file) => ({ file, handle: null }));
+      input.remove();
+      resolve(multiple ? files : files[0] ?? null);
+    });
+    input.addEventListener('cancel', () => {
+      input.remove();
+      resolve(multiple ? [] : null);
+    });
+    document.body.append(input);
+    input.click();
+  });
+}
+
+export async function pickSave({ suggestedName, types = [] } = {}) {
+  if (supportsFileSystemAccess() && window.showSaveFilePicker) {
+    const handle = await window.showSaveFilePicker({ suggestedName, types });
+    return {
+      kind: 'handle',
+      handle,
+      suggestedName: handle.name || suggestedName,
+      async write(contents, type = 'application/octet-stream') {
+        const blob =
+          contents instanceof Blob ? contents : new Blob([contents], { type });
+        const writable = await handle.createWritable();
+        await writable.write(blob);
+        await writable.close();
+      },
+    };
+  }
+
+  const accept = buildAcceptString(types);
+  let downloadName = suggestedName || 'download';
+  if (accept) {
+    const ext = accept
+      .split(',')
+      .map((part) => part.trim())
+      .find((part) => part.startsWith('.'));
+    if (ext && !downloadName.toLowerCase().endsWith(ext.toLowerCase())) {
+      downloadName += ext;
+    }
+  }
+
+  return {
+    kind: 'download',
+    handle: null,
+    suggestedName: downloadName,
+    async write(contents, type = 'application/octet-stream') {
+      const blob =
+        contents instanceof Blob ? contents : new Blob([contents], { type });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.style.display = 'none';
+      anchor.href = url;
+      anchor.download = downloadName;
+      document.body.append(anchor);
+      anchor.click();
+      const cleanup = () => {
+        anchor.remove();
+        URL.revokeObjectURL(url);
+      };
+      if (typeof requestAnimationFrame === 'function') requestAnimationFrame(cleanup);
+      else setTimeout(cleanup, 0);
+    },
+  };
+}
+
+export function __test__buildAcceptString(types) {
+  return buildAcceptString(types);
+}

--- a/style.css
+++ b/style.css
@@ -953,32 +953,17 @@ body {
 }
 
 /* Notepad specific styles */
-.notepad-toolbar {
+.notepad {
   display: flex;
-  gap: 6px;
-  margin-bottom: 4px;
+  height: 100%;
 }
 
-.notepad-toolbar button {
-  padding: 2px 6px;
-  font-size: 12px;
-  cursor: pointer;
+.notepad-layout {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
 }
 
-/* Notepad editor area – CodeMirror will override height */
-/* The Notepad editor area sits below a fixed toolbar.  Adjust the heights
-   here if you change the toolbar’s height in the HTML. */
-.notepad-editor {
-  width: 100%;
-  height: calc(100% - 32px);
-}
-
-/* Ensure CodeMirror fills the notepad window */
-.CodeMirror {
-  height: calc(100% - 32px);
-}
-
-/* Notepad menu bar */
 .notepad-menu {
   display: flex;
   align-items: center;
@@ -987,16 +972,40 @@ body {
   background: var(--taskbar-bg);
   border-bottom: 2px solid var(--taskbar-border-dark);
 }
+
 .notepad-menu button {
   font-size: 12px;
   padding: 2px 6px;
   cursor: pointer;
 }
+
 .notepad-menu button.active {
   background: var(--selection-bg);
   color: var(--window-bg);
   border-color: #000000 #ffffff #ffffff #000000;
   padding: 3px 5px 1px 7px;
+}
+
+.notepad-editor-host {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
+.notepad-textarea {
+  flex: 1;
+}
+
+.CodeMirror {
+  flex: 1;
+  height: 100%;
+}
+
+.notepad-status {
+  padding: 4px 8px;
+  font-size: 12px;
+  border-top: 1px solid var(--window-border-dark);
+  background: var(--taskbar-bg);
 }
 
 /* Terminal styles */
@@ -1063,12 +1072,37 @@ body {
   cursor: pointer;
 }
 
+.file-manager-toolbar input[type='text'] {
+  padding: 2px 6px;
+  font-size: 12px;
+  min-width: 120px;
+}
+
 /* New two-pane file manager */
 .file-manager-body {
   flex: 1;
   display: flex;
   overflow: hidden;
   border-top: 1px solid var(--window-border-dark);
+}
+
+.file-breadcrumbs {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: 2px 0 6px;
+  font-size: 12px;
+}
+
+.file-breadcrumbs button {
+  font-size: 12px;
+  padding: 2px 6px;
+  cursor: pointer;
+}
+
+.breadcrumb-separator {
+  opacity: 0.6;
 }
 
 .file-tree {
@@ -1082,6 +1116,23 @@ body {
   flex: 1;
   overflow-y: auto;
   padding: 4px;
+}
+
+.file-view-toggle {
+  margin-left: auto;
+  display: flex;
+  gap: 4px;
+}
+
+.file-view-toggle button {
+  font-size: 12px;
+  padding: 2px 6px;
+}
+
+.file-view-toggle button.active {
+  background: var(--selection-bg);
+  color: #ffffff;
+  border-color: #000000 #ffffff #ffffff #000000;
 }
 
 /* Legacy content container for other panels */
@@ -1151,6 +1202,44 @@ body {
 .file-item.selected {
   background: var(--selection-bg);
   color: #ffffff;
+}
+
+.file-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 12px;
+  padding: 4px 0;
+}
+
+.file-card {
+  border: 1px solid transparent;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  text-align: center;
+}
+
+.file-card:hover {
+  background: var(--selection-bg);
+  color: #ffffff;
+}
+
+.file-card.selected {
+  background: var(--selection-bg);
+  color: #ffffff;
+  border-color: #ffffff;
+}
+
+.file-card-icon {
+  font-size: 24px;
+}
+
+.file-card-label {
+  font-size: 12px;
+  word-break: break-word;
 }
 
 .tree-node {

--- a/tests/notepad.test.js
+++ b/tests/notepad.test.js
@@ -1,0 +1,403 @@
+import assert from 'assert';
+import { mount as mountNotepad } from '../src/js/apps/notepad.js';
+
+class LocalStorage {
+  constructor() {
+    this.store = new Map();
+  }
+  getItem(key) {
+    return this.store.has(key) ? this.store.get(key) : null;
+  }
+  setItem(key, value) {
+    this.store.set(String(key), String(value));
+  }
+  removeItem(key) {
+    this.store.delete(String(key));
+  }
+  clear() {
+    this.store.clear();
+  }
+}
+
+class ClassList {
+  constructor(owner) {
+    this.owner = owner;
+    this._set = new Set();
+  }
+  _sync() {
+    this.owner._className = Array.from(this._set).join(' ');
+  }
+  add(...classes) {
+    classes.forEach((cls) => {
+      if (!cls) return;
+      this._set.add(cls);
+    });
+    this._sync();
+  }
+  remove(...classes) {
+    classes.forEach((cls) => this._set.delete(cls));
+    this._sync();
+  }
+  toggle(cls, force) {
+    if (force === undefined) {
+      if (this._set.has(cls)) {
+        this._set.delete(cls);
+        this._sync();
+        return false;
+      }
+      this._set.add(cls);
+      this._sync();
+      return true;
+    }
+    if (force) this.add(cls);
+    else this.remove(cls);
+    return force;
+  }
+  contains(cls) {
+    return this._set.has(cls);
+  }
+  toString() {
+    return Array.from(this._set).join(' ');
+  }
+}
+
+class Element {
+  constructor(tagName) {
+    this.tagName = tagName.toUpperCase();
+    this.children = [];
+    this.parent = null;
+    this.ownerDocument = null;
+    this.dataset = {};
+    this.style = {};
+    this.eventListeners = new Map();
+    this._text = '';
+    this._className = '';
+    this.classList = new ClassList(this);
+    this.value = '';
+  }
+  append(...nodes) {
+    nodes.forEach((node) => this.appendChild(node));
+  }
+  appendChild(node) {
+    if (node == null) return;
+    node.parent = this;
+    node.ownerDocument = this.ownerDocument;
+    this.children.push(node);
+    return node;
+  }
+  remove() {
+    if (!this.parent) return;
+    const idx = this.parent.children.indexOf(this);
+    if (idx >= 0) this.parent.children.splice(idx, 1);
+    this.parent = null;
+  }
+  get textContent() {
+    return this._text;
+  }
+  set textContent(value) {
+    this._text = String(value ?? '');
+  }
+  get className() {
+    return this._className;
+  }
+  set className(value) {
+    this._className = String(value ?? '');
+    this.classList = new ClassList(this);
+    if (this._className.trim()) {
+      this._className
+        .trim()
+        .split(/\s+/)
+        .forEach((cls) => this.classList.add(cls));
+    }
+  }
+  addEventListener(type, handler) {
+    if (!this.eventListeners.has(type)) this.eventListeners.set(type, []);
+    this.eventListeners.get(type).push(handler);
+  }
+  removeEventListener(type, handler) {
+    const list = this.eventListeners.get(type);
+    if (!list) return;
+    const idx = list.indexOf(handler);
+    if (idx >= 0) list.splice(idx, 1);
+  }
+  dispatchEvent(event) {
+    event.target = this;
+    event.currentTarget = this;
+    if (event.cancelable && typeof event.preventDefault !== 'function') {
+      event.preventDefault = () => {
+        event.defaultPrevented = true;
+      };
+    }
+    const handlers = this.eventListeners.get(event.type) || [];
+    handlers.slice().forEach((handler) => handler.call(this, event));
+    return !event.defaultPrevented;
+  }
+  querySelector(selector) {
+    return this.querySelectorAll(selector)[0] ?? null;
+  }
+  querySelectorAll(selector) {
+    const tokens = selector.trim().split(/\s+/);
+    const results = [];
+    const traverse = (node) => {
+      node.children.forEach((child) => {
+        if (matchesComplex(child, tokens)) results.push(child);
+        traverse(child);
+      });
+    };
+    traverse(this);
+    return results;
+  }
+}
+
+class Document extends Element {
+  constructor() {
+    super('#document');
+    this.ownerDocument = this;
+    this.body = new Element('body');
+    this.body.ownerDocument = this;
+    this.appendChild(this.body);
+  }
+  createElement(tagName) {
+    const el = new Element(tagName);
+    el.ownerDocument = this;
+    return el;
+  }
+  querySelector(selector) {
+    return this.body.querySelector(selector);
+  }
+  querySelectorAll(selector) {
+    return this.body.querySelectorAll(selector);
+  }
+}
+
+class CustomEvt {
+  constructor(type, options = {}) {
+    this.type = type;
+    this.detail = options.detail;
+    this.cancelable = Boolean(options.cancelable);
+    this.defaultPrevented = false;
+  }
+  preventDefault() {
+    if (this.cancelable) this.defaultPrevented = true;
+  }
+}
+
+function matchesSimple(element, selector) {
+  if (selector.startsWith('.')) return element.classList.contains(selector.slice(1));
+  if (selector.startsWith('#')) return element.id === selector.slice(1);
+  return element.tagName === selector.toUpperCase();
+}
+
+function matchesComplex(element, tokens) {
+  const last = tokens[tokens.length - 1];
+  if (!matchesSimple(element, last)) return false;
+  let current = element.parent;
+  for (let i = tokens.length - 2; i >= 0; i -= 1) {
+    const token = tokens[i];
+    while (current && !matchesSimple(current, token)) {
+      current = current.parent;
+    }
+    if (!current) return false;
+    current = current.parent;
+  }
+  return true;
+}
+
+function createStubCodeMirror() {
+  return {
+    fromTextArea(textarea) {
+      let value = textarea.value || '';
+      const listeners = { change: [], cursorActivity: [] };
+      const emit = (type) => {
+        for (const handler of listeners[type] || []) handler();
+      };
+      return {
+        setValue(text) {
+          value = text ?? '';
+          textarea.value = value;
+          emit('change');
+          emit('cursorActivity');
+        },
+        getValue() {
+          return value;
+        },
+        on(event, handler) {
+          (listeners[event] || (listeners[event] = [])).push(handler);
+        },
+        off(event, handler) {
+          if (!listeners[event]) return;
+          listeners[event] = listeners[event].filter((fn) => fn !== handler);
+        },
+        focus() {},
+        refresh() {},
+        setOption() {},
+        undo() {},
+        redo() {},
+        setSize() {},
+        getCursor() {
+          return { line: 0, ch: value.length };
+        },
+      };
+    },
+  };
+}
+
+const document = new Document();
+const windowListeners = new Map();
+const windowObj = {
+  document,
+  CustomEvent: CustomEvt,
+  confirm: () => true,
+  addEventListener(type, handler) {
+    if (!windowListeners.has(type)) windowListeners.set(type, []);
+    windowListeners.get(type).push(handler);
+  },
+  removeEventListener(type, handler) {
+    const list = windowListeners.get(type);
+    if (!list) return;
+    const idx = list.indexOf(handler);
+    if (idx >= 0) list.splice(idx, 1);
+  },
+  dispatchEvent(event) {
+    const handlers = windowListeners.get(event.type) || [];
+    handlers.slice().forEach((handler) => handler.call(windowObj, event));
+    return !event.defaultPrevented;
+  },
+  requestAnimationFrame: (cb) => setTimeout(cb, 0),
+  setTimeout,
+  clearTimeout,
+  setInterval,
+  clearInterval,
+  localStorage: new LocalStorage(),
+};
+
+global.window = windowObj;
+global.document = document;
+global.CustomEvent = CustomEvt;
+global.localStorage = windowObj.localStorage;
+global.requestAnimationFrame = windowObj.requestAnimationFrame;
+
+function createWindowShell() {
+  const win = document.createElement('div');
+  win.classList.add('window');
+  const header = document.createElement('div');
+  header.classList.add('window-header');
+  const title = document.createElement('span');
+  title.classList.add('title');
+  header.append(title);
+  const content = document.createElement('div');
+  content.classList.add('content');
+  win.append(header, content);
+  document.body.append(win);
+  return win;
+}
+
+async function createNotepadContext() {
+  const winEl = createWindowShell();
+  const writes = [];
+  const handle = {
+    name: 'note.txt',
+    async createWritable() {
+      return {
+        async write(data) {
+          if (data instanceof Blob) {
+            writes.push(await data.text());
+          } else {
+            writes.push(data);
+          }
+        },
+        async close() {},
+      };
+    },
+    async queryPermission() {
+      return 'granted';
+    },
+    async requestPermission() {
+      return 'granted';
+    },
+  };
+
+  const ctx = {
+    codeMirrorLoader: async () => createStubCodeMirror(),
+    fileDialogs: {
+      pickOpen: async () => null,
+      pickSave: async () => ({
+        handle,
+        async write(data) {
+          if (data instanceof Blob) {
+            writes.push(await data.text());
+          } else {
+            writes.push(data);
+          }
+        },
+      }),
+    },
+  };
+
+  const api = await mountNotepad(winEl, ctx);
+  return { api, winEl, writes };
+}
+
+async function testSaveRoundTrip() {
+  localStorage.clear();
+  window.confirm = () => true;
+  const { api, winEl, writes } = await createNotepadContext();
+  api.setValue('Hello world');
+  assert.strictEqual(api.isDirty(), true);
+
+  await api.saveAs();
+  assert.ok(writes.length > 0);
+  assert.strictEqual(writes[writes.length - 1], 'Hello world');
+  assert.strictEqual(api.isDirty(), false);
+
+  api.setValue('Updated text');
+  assert.strictEqual(api.isDirty(), true);
+  await api.save();
+  assert.strictEqual(writes[writes.length - 1], 'Updated text');
+  assert.strictEqual(api.isDirty(), false);
+
+  api.dispose();
+  winEl.dispatchEvent(new CustomEvt('window-closed'));
+  winEl.remove();
+}
+
+async function testDirtyWarning() {
+  localStorage.clear();
+  let confirmCalls = 0;
+  window.confirm = () => {
+    confirmCalls += 1;
+    return false;
+  };
+  const { api, winEl } = await createNotepadContext();
+  api.setValue('Unsaved');
+
+  const attempt = new CustomEvt('window-before-close', { cancelable: true });
+  winEl.dispatchEvent(attempt);
+  assert.strictEqual(confirmCalls, 1);
+  assert.strictEqual(attempt.defaultPrevented, true);
+
+  window.confirm = () => {
+    throw new Error('confirm should not be called when clean');
+  };
+  await api.saveAs();
+  const second = new CustomEvt('window-before-close', { cancelable: true });
+  const result = winEl.dispatchEvent(second);
+  assert.strictEqual(result, true);
+  assert.strictEqual(second.defaultPrevented, false);
+
+  api.dispose();
+  winEl.dispatchEvent(new CustomEvt('window-closed'));
+  winEl.remove();
+  window.confirm = () => true;
+}
+
+async function run() {
+  await testSaveRoundTrip();
+  await testDirtyWarning();
+  console.log('notepad tests passed');
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
* Add reusable file dialog helpers that prefer the File System Access API with graceful fallbacks and wire them into the Notepad, File Manager, Gallery, and Media Player apps.【F:src/js/utils/file-dialogs.js†L1-L112】【F:src/js/apps/file-manager.js†L41-L195】【F:src/js/apps/gallery.js†L1-L78】【F:src/js/apps/media-player.js†L1-L78】
* Rebuild Notepad with lazy CodeMirror loading, autosave, status bar, keyboard shortcuts, File System Access support, and an unsaved-changes close guard.【F:src/js/apps/notepad.js†L1-L360】
* Upgrade File Manager with breadcrumbs, list and grid views, keyboard selection, and refreshed styling to improve navigation and selection controls.【F:src/js/apps/file-manager.js†L41-L593】【F:style.css†L955-L1243】
* Emit cancelable window-before-close events so apps can block closes when state is dirty.【F:src/js/core/windowManager.js†L224-L254】
* Add Node-based Notepad tests using DOM stubs to verify save round-trips and unsaved warnings fire.【F:tests/notepad.test.js†L1-L403】

## Testing
* `npm test`【8cbc2a†L1-L10】

------
https://chatgpt.com/codex/tasks/task_e_68ce4a3beb448330b1fcfd3bb3926f8b