### PR TITLE
Implement media utilities and upgraded editors

### DIFF
--- a/src/js/apps/file-manager.js
+++ b/src/js/apps/file-manager.js
@@ -1,6 +1,7 @@
 import * as notepad from './notepad.js';
 import * as gallery from './gallery.js';
 import * as sheets from './sheets.js';
+import * as mediaPlayer from './media-player.js';
 import { APIClient } from '../utils/api.js';
 import { pickOpen } from '../utils/file-dialogs.js';
 
@@ -450,15 +451,32 @@ export function mount(winEl, ctx) {
     const ext = item.name.split('.').pop().toLowerCase();
     const url = fileURL(item.path);
     try {
-      if (['txt', 'js', 'json', 'md', 'py', 'css', 'html'].includes(ext)) {
+      if (['txt', 'js', 'json', 'md', 'py', 'css', 'html', 'log'].includes(ext)) {
         const res = await api.get(url, {}, 'text');
         if (!res.ok) throw new Error(res.error);
-        notepad.launch(ctx, res.data);
-      } else if (['png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp'].includes(ext)) {
+        notepad.launch(ctx, {
+          content: res.data,
+          name: item.name,
+          path: item.path,
+        });
+      } else if (['png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp', 'avif'].includes(ext)) {
         const res = await api.get(url, {}, 'blob');
         if (!res.ok) throw new Error(res.error);
-        const objectUrl = URL.createObjectURL(res.data);
-        gallery.launch(ctx, [objectUrl]);
+        gallery.launch(ctx, [
+          {
+            name: item.name,
+            path: item.path,
+            blob: res.data,
+          },
+        ]);
+      } else if (['mp3', 'wav', 'ogg', 'webm', 'mp4', 'm4a', 'm4v', 'mov'].includes(ext)) {
+        const res = await api.get(url, {}, 'blob');
+        if (!res.ok) throw new Error(res.error);
+        mediaPlayer.launch(ctx, {
+          name: item.name,
+          path: item.path,
+          blob: res.data,
+        });
       } else if (ext === 'csv') {
         const res = await api.get(url, {}, 'text');
         if (!res.ok) throw new Error(res.error);

--- a/src/js/apps/gallery.js
+++ b/src/js/apps/gallery.js
@@ -2,99 +2,233 @@
 import { pickOpen } from '../utils/file-dialogs.js';
 
 export const meta = { id: 'gallery', name: 'Gallery', icon: '/icons/gallery.png' };
+
 export function launch(ctx, initialImages = []) {
   const content = document.createElement('div');
   const id = ctx.windowManager.createWindow(meta.id, meta.name, content);
-  const win = ctx.windowManager.windows.get(id).element;
+  const win = ctx.windowManager.windows.get(id)?.element;
+  if (!win) return;
   mount(win, ctx, initialImages);
 }
+
 export function mount(winEl, ctx, initialImages = []) {
   ctx.globals.addLog?.('Gallery opened');
   const container = winEl.classList.contains('window')
     ? winEl.querySelector('.content')
     : winEl;
   if (!container) return;
+
   container.innerHTML = '';
-  container.classList.add('file-manager');
+  container.classList.add('gallery');
 
   const toolbar = document.createElement('div');
-  toolbar.classList.add('file-manager-toolbar');
+  toolbar.classList.add('gallery-toolbar');
   const addBtn = document.createElement('button');
   addBtn.textContent = 'Add Images';
   toolbar.append(addBtn);
 
-  const content = document.createElement('div');
-  content.classList.add('file-manager-content');
-  content.style.display = 'flex';
-  content.style.flexWrap = 'wrap';
-  content.style.gap = '8px';
-  container.append(toolbar, content);
+  const grid = document.createElement('div');
+  grid.classList.add('gallery-grid');
 
-  function renderThumbnail(src) {
-    const thumb = document.createElement('img');
-    thumb.src = src;
-    thumb.style.width = '80px';
-    thumb.style.height = '80px';
-    thumb.style.objectFit = 'cover';
-    thumb.style.cursor = 'pointer';
-    thumb.addEventListener('click', () => {
-      const viewer = document.createElement('img');
-      viewer.src = src;
-      viewer.style.maxWidth = '100%';
-      viewer.style.maxHeight = '100%';
-      const viewContainer = document.createElement('div');
-      viewContainer.style.display = 'flex';
-      viewContainer.style.justifyContent = 'center';
-      viewContainer.style.alignItems = 'center';
-      viewContainer.style.height = '100%';
-      viewContainer.append(viewer);
-      ctx.windowManager.createWindow('image', 'Image Viewer', viewContainer);
+  container.append(toolbar, grid);
+
+  const dialogs = {
+    pickOpen: ctx?.fileDialogs?.pickOpen ?? pickOpen,
+  };
+
+  let counter = 0;
+  const items = [];
+  const FileCtor = typeof File !== 'undefined' ? File : null;
+  const BlobCtor = typeof Blob !== 'undefined' ? Blob : null;
+
+  function normalizeSource(src) {
+    if (!src) return null;
+    counter += 1;
+    const base = { id: `img-${counter}` };
+    if ((FileCtor && src instanceof FileCtor) || (BlobCtor && src instanceof BlobCtor)) {
+      return { ...base, blob: src, name: src.name || 'Image' };
+    }
+    if (typeof src === 'string') {
+      return { ...base, src };
+    }
+    if (FileCtor && src.file instanceof FileCtor) {
+      return { ...base, blob: src.file, name: src.file.name || src.name, path: src.path };
+    }
+    if (BlobCtor && src.blob instanceof BlobCtor) {
+      return { ...base, blob: src.blob, name: src.name, path: src.path };
+    }
+    if (src.src) {
+      return { ...base, src: src.src, name: src.name, path: src.path };
+    }
+    return null;
+  }
+
+  function releaseItem(item) {
+    if (item.objectUrl) {
+      URL.revokeObjectURL(item.objectUrl);
+      item.objectUrl = null;
+    }
+  }
+
+  async function ensureBlob(item) {
+    if (item.blob) return item.blob;
+    if (item.src && typeof fetch === 'function') {
+      try {
+        const res = await fetch(item.src, { mode: 'cors' });
+        const blob = await res.blob();
+        item.blob = blob;
+        return blob;
+      } catch (err) {
+        console.warn('Unable to fetch image for thumbnail', err);
+        return null;
+      }
+    }
+    return null;
+  }
+
+  async function ensureFullUrl(item) {
+    if (item.objectUrl) return item.objectUrl;
+    if (item.blob) {
+      item.objectUrl = URL.createObjectURL(item.blob);
+      return item.objectUrl;
+    }
+    return item.src || '';
+  }
+
+  async function createThumbnail(item) {
+    if (item.thumbUrl) return item.thumbUrl;
+    const blob = await ensureBlob(item);
+    if (blob && typeof createImageBitmap === 'function') {
+      try {
+        const bitmap = await createImageBitmap(blob, {
+          resizeWidth: 256,
+          resizeHeight: 256,
+          resizeQuality: 'high',
+        });
+        const maxDim = 128;
+        const scale = Math.min(1, maxDim / Math.max(bitmap.width, bitmap.height));
+        const width = Math.max(1, Math.round(bitmap.width * scale || 1));
+        const height = Math.max(1, Math.round(bitmap.height * scale || 1));
+        const canvas = document.createElement('canvas');
+        canvas.width = width;
+        canvas.height = height;
+        const ctx2d = canvas.getContext('2d');
+        ctx2d.drawImage(bitmap, 0, 0, width, height);
+        bitmap.close();
+        item.thumbUrl = canvas.toDataURL('image/png');
+        return item.thumbUrl;
+      } catch (err) {
+        console.warn('Thumbnail generation failed', err);
+      }
+    }
+    const url = await ensureFullUrl(item);
+    item.thumbUrl = url;
+    return url;
+  }
+
+  function openFullView(item) {
+    ensureFullUrl(item).then((url) => {
+      if (!url) return;
+      const wrapper = document.createElement('div');
+      wrapper.classList.add('gallery-viewer');
+      const img = document.createElement('img');
+      img.src = url;
+      img.alt = item.name || 'Image';
+      wrapper.append(img);
+      ctx.windowManager.createWindow(
+        `gallery-view-${Date.now()}`,
+        item.name || item.path || 'Image',
+        wrapper,
+      );
     });
-    content.append(thumb);
   }
 
-  function addImageFromSource(src) {
-    if (!src) return;
-    renderThumbnail(src);
+  function createCard(item) {
+    const card = document.createElement('button');
+    card.type = 'button';
+    card.classList.add('gallery-card');
+    card.dataset.id = item.id;
+
+    const thumb = document.createElement('div');
+    thumb.classList.add('gallery-thumb');
+    thumb.textContent = 'Loading…';
+
+    const label = document.createElement('span');
+    label.classList.add('gallery-label');
+    label.textContent = item.name || item.path || 'Image';
+
+    card.append(thumb, label);
+
+    createThumbnail(item)
+      .then((url) => {
+        if (!card.isConnected || !url) return;
+        thumb.style.backgroundImage = `url(${url})`;
+        thumb.textContent = '';
+      })
+      .catch((err) => {
+        console.warn('Failed to render thumbnail', err);
+        if (card.isConnected) thumb.textContent = 'Preview unavailable';
+      });
+
+    card.addEventListener('click', () => openFullView(item));
+
+    return card;
   }
 
-  initialImages.forEach((img) => {
-    if (typeof img === 'string') addImageFromSource(img);
-    else if (img && typeof img.src === 'string') addImageFromSource(img.src);
-  });
+  function render() {
+    grid.innerHTML = '';
+    if (items.length === 0) {
+      const empty = document.createElement('p');
+      empty.classList.add('gallery-empty');
+      empty.textContent = 'No images yet. Use “Add Images” to import.';
+      grid.append(empty);
+      return;
+    }
+    items.forEach((item) => {
+      grid.append(createCard(item));
+    });
+  }
+
+  function addImages(sources) {
+    const normalized = sources
+      .map((src) => normalizeSource(src))
+      .filter(Boolean);
+    if (!normalized.length) return;
+    items.push(...normalized);
+    render();
+  }
+
+  const initialList = Array.isArray(initialImages) ? initialImages : [initialImages];
+  addImages(initialList);
 
   addBtn.addEventListener('click', async () => {
     try {
-      const selection = await (ctx?.fileDialogs?.pickOpen
-        ? ctx.fileDialogs.pickOpen({
-            types: [
-              {
-                description: 'Images',
-                accept: { 'image/*': ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp'] },
-              },
-            ],
-            multiple: true,
-          })
-        : pickOpen({
-            types: [
-              {
-                description: 'Images',
-                accept: { 'image/*': ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp'] },
-              },
-            ],
-            multiple: true,
-          }));
+      const selection = await dialogs.pickOpen({
+        types: [
+          {
+            description: 'Images',
+            accept: {
+              'image/*': ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp', '.avif'],
+            },
+          },
+        ],
+        multiple: true,
+      });
       const entries = Array.isArray(selection)
         ? selection
         : selection
         ? [selection]
         : [];
-      for (const entry of entries) {
-        const url = URL.createObjectURL(entry.file);
-        addImageFromSource(url);
-      }
+      addImages(entries.map((entry) => ({ file: entry.file, path: entry.handle?.name })));
     } catch (err) {
-      console.error(err);
+      console.error('Image picker failed', err);
     }
   });
+
+  render();
+
+  const cleanup = () => {
+    items.forEach(releaseItem);
+  };
+  winEl.addEventListener('window-closed', cleanup, { once: true });
 }

--- a/src/js/apps/media-player.js
+++ b/src/js/apps/media-player.js
@@ -2,95 +2,237 @@
 import { pickOpen } from '../utils/file-dialogs.js';
 
 export const meta = { id: 'media-player', name: 'Media Player', icon: '/icons/media-player.png' };
-export function launch(ctx) {
+
+export function launch(ctx, initial = null) {
   const content = document.createElement('div');
   const id = ctx.windowManager.createWindow(meta.id, meta.name, content);
-  const win = ctx.windowManager.windows.get(id).element;
-  mount(win, ctx);
+  const win = ctx.windowManager.windows.get(id)?.element;
+  if (!win) return;
+  mount(win, ctx, initial);
 }
-export function mount(winEl, ctx) {
+
+export function mount(winEl, ctx, initial = null) {
   ctx.globals.addLog?.('Media Player opened');
   const container = winEl.classList.contains('window')
     ? winEl.querySelector('.content')
     : winEl;
   if (!container) return;
+
   container.innerHTML = '';
-  container.classList.add('file-manager');
+  container.classList.add('media-player');
+
+  const dialogs = {
+    pickOpen: ctx?.fileDialogs?.pickOpen ?? pickOpen,
+  };
+  const BlobCtor = typeof Blob !== 'undefined' ? Blob : null;
 
   const toolbar = document.createElement('div');
-  toolbar.classList.add('file-manager-toolbar');
+  toolbar.classList.add('media-player-toolbar');
   const openBtn = document.createElement('button');
   openBtn.textContent = 'Open Media';
   toolbar.append(openBtn);
 
-  const content = document.createElement('div');
-  content.classList.add('file-manager-content');
-  container.append(toolbar, content);
+  const stage = document.createElement('div');
+  stage.classList.add('media-player-stage');
+
+  const controls = document.createElement('div');
+  controls.classList.add('media-player-controls');
+  const playPause = document.createElement('button');
+  playPause.textContent = 'Play';
+  playPause.disabled = true;
+  const seek = document.createElement('input');
+  seek.type = 'range';
+  seek.min = '0';
+  seek.max = '0';
+  seek.step = '0.01';
+  seek.value = '0';
+  seek.disabled = true;
+  const timeLabel = document.createElement('span');
+  timeLabel.textContent = '0:00 / 0:00';
+  controls.append(playPause, seek, timeLabel);
+
+  const status = document.createElement('div');
+  status.classList.add('media-player-status');
+  status.textContent = 'No media loaded.';
+
+  container.append(toolbar, stage, controls, status);
 
   let currentEl = null;
+  let currentSource = null;
+  let cleanupAudio = null;
+  let scrubbing = false;
 
-  async function loadFile(file) {
-    if (!file) return;
-    const url = URL.createObjectURL(file);
-    content.innerHTML = '';
+  function formatTime(value) {
+    if (!Number.isFinite(value) || value < 0) return '0:00';
+    const whole = Math.floor(value);
+    const minutes = Math.floor(whole / 60);
+    const seconds = String(whole % 60).padStart(2, '0');
+    return `${minutes}:${seconds}`;
+  }
+
+  function detectType(source) {
+    const mime = source?.mime || source?.blob?.type || '';
+    if (mime.startsWith('video/')) return 'video';
+    if (mime.startsWith('audio/')) return 'audio';
+    const name = source?.name || '';
+    const ext = name.split('.').pop().toLowerCase();
+    if (['mp4', 'webm', 'mkv', 'mov', 'm4v'].includes(ext)) return 'video';
+    if (['mp3', 'wav', 'ogg', 'm4a', 'flac'].includes(ext)) return 'audio';
+    return mime.startsWith('video') ? 'video' : 'audio';
+  }
+
+  function disposeCurrent() {
     if (currentEl) {
-      currentEl.pause();
-      currentEl.src = '';
+      try {
+        currentEl.pause();
+      } catch (err) {
+        /* ignore */
+      }
+      currentEl.remove();
       currentEl = null;
     }
-    if (file.type.startsWith('video')) {
-      currentEl = document.createElement('video');
-      currentEl.controls = true;
-      currentEl.style.maxWidth = '100%';
-      currentEl.style.maxHeight = '100%';
-      currentEl.src = url;
-      ctx.globals.addAudioElement?.(currentEl);
-      content.append(currentEl);
-      currentEl.play();
-    } else if (file.type.startsWith('audio')) {
-      currentEl = document.createElement('audio');
-      currentEl.controls = true;
-      currentEl.src = url;
-      ctx.globals.addAudioElement?.(currentEl);
-      content.append(currentEl);
-      currentEl.play();
-    } else {
-      const p = document.createElement('p');
-      p.textContent = 'Unsupported file type.';
-      content.append(p);
+    stage.innerHTML = '';
+    if (cleanupAudio) {
+      cleanupAudio();
+      cleanupAudio = null;
     }
+    if (currentSource?.ownedUrl) {
+      URL.revokeObjectURL(currentSource.ownedUrl);
+    }
+    currentSource = null;
+    playPause.disabled = true;
+    seek.disabled = true;
+    seek.value = '0';
+    seek.max = '0';
+    timeLabel.textContent = '0:00 / 0:00';
+    status.textContent = 'No media loaded.';
+  }
+
+  function updateTimeUI() {
+    if (!currentEl) return;
+    const { currentTime, duration, paused } = currentEl;
+    if (!scrubbing) seek.value = String(currentTime || 0);
+    if (Number.isFinite(duration) && duration > 0) {
+      seek.max = String(duration);
+      timeLabel.textContent = `${formatTime(currentTime)} / ${formatTime(duration)}`;
+    } else {
+      timeLabel.textContent = `${formatTime(currentTime)} / 0:00`;
+    }
+    playPause.textContent = paused ? 'Play' : 'Pause';
+  }
+
+  function wireMedia(el) {
+    el.addEventListener('loadedmetadata', () => {
+      seek.disabled = false;
+      playPause.disabled = false;
+      seek.max = Number.isFinite(el.duration) ? String(el.duration) : '0';
+      updateTimeUI();
+    });
+    el.addEventListener('timeupdate', updateTimeUI);
+    el.addEventListener('play', updateTimeUI);
+    el.addEventListener('pause', updateTimeUI);
+    el.addEventListener('ended', updateTimeUI);
+  }
+
+  async function loadSource(source) {
+    if (!source) return;
+    let normalized = source;
+    if (typeof source === 'string') {
+      normalized = { src: source };
+    } else if (BlobCtor && source instanceof BlobCtor) {
+      normalized = { blob: source };
+    }
+    disposeCurrent();
+    const type = detectType(normalized) || 'audio';
+    const mediaEl = document.createElement(type === 'video' ? 'video' : 'audio');
+    mediaEl.controls = true;
+    mediaEl.style.maxWidth = '100%';
+    mediaEl.style.maxHeight = '100%';
+
+    let url = normalized.url || normalized.src || '';
+    if (!url && BlobCtor && normalized.blob instanceof BlobCtor) {
+      url = URL.createObjectURL(normalized.blob);
+      normalized.ownedUrl = url;
+    }
+    if (!url) {
+      status.textContent = 'Unsupported media format.';
+      return;
+    }
+    mediaEl.src = url;
+    stage.innerHTML = '';
+    stage.append(mediaEl);
+    currentEl = mediaEl;
+    currentSource = normalized;
+    cleanupAudio = ctx.globals.addAudioElement?.(mediaEl) || null;
+    status.textContent = normalized.name || normalized.path || 'Playing media';
+    wireMedia(mediaEl);
+    try {
+      await mediaEl.play();
+    } catch (err) {
+      console.warn('Autoplay prevented', err);
+    }
+    updateTimeUI();
   }
 
   openBtn.addEventListener('click', async () => {
     try {
-      const selection = await (ctx?.fileDialogs?.pickOpen
-        ? ctx.fileDialogs.pickOpen({
-            types: [
-              {
-                description: 'Media',
-                accept: {
-                  'audio/*': ['.mp3', '.wav', '.ogg'],
-                  'video/*': ['.mp4', '.webm', '.ogg'],
-                },
-              },
-            ],
-          })
-        : pickOpen({
-            types: [
-              {
-                description: 'Media',
-                accept: {
-                  'audio/*': ['.mp3', '.wav', '.ogg'],
-                  'video/*': ['.mp4', '.webm', '.ogg'],
-                },
-              },
-            ],
-          }));
+      const selection = await dialogs.pickOpen({
+        types: [
+          {
+            description: 'Media',
+            accept: {
+              'audio/*': ['.mp3', '.wav', '.ogg', '.m4a', '.flac'],
+              'video/*': ['.mp4', '.webm', '.ogg', '.mov', '.m4v'],
+            },
+          },
+        ],
+        multiple: false,
+      });
       const entry = Array.isArray(selection) ? selection[0] : selection;
       if (!entry) return;
-      await loadFile(entry.file);
+      await loadSource({ blob: entry.file, name: entry.file?.name });
     } catch (err) {
-      console.error(err);
+      console.error('Media picker failed', err);
     }
   });
+
+  playPause.addEventListener('click', () => {
+    if (!currentEl) return;
+    if (currentEl.paused) currentEl.play().catch(() => {});
+    else currentEl.pause();
+  });
+
+  seek.addEventListener('input', () => {
+    if (!currentEl) return;
+    scrubbing = true;
+    const next = parseFloat(seek.value);
+    if (Number.isFinite(next)) {
+      currentEl.currentTime = next;
+    }
+  });
+  seek.addEventListener('change', () => {
+    scrubbing = false;
+    updateTimeUI();
+  });
+  seek.addEventListener('pointerup', () => {
+    scrubbing = false;
+    updateTimeUI();
+  });
+  seek.addEventListener('keyup', () => {
+    scrubbing = false;
+    updateTimeUI();
+  });
+  seek.addEventListener('touchend', () => {
+    scrubbing = false;
+    updateTimeUI();
+  });
+
+  const cleanup = () => {
+    disposeCurrent();
+  };
+  winEl.addEventListener('window-closed', cleanup, { once: true });
+
+  if (initial) {
+    loadSource(initial);
+  }
 }

--- a/src/js/apps/recorder.js
+++ b/src/js/apps/recorder.js
@@ -1,16 +1,23 @@
 
 export const meta = { id: 'recorder', name: 'Recorder', icon: '/icons/recorder.png' };
+
 export function launch(ctx) {
   const content = document.createElement('div');
   const id = ctx.windowManager.createWindow(meta.id, meta.name, content);
-  const win = ctx.windowManager.windows.get(id).element;
+  const win = ctx.windowManager.windows.get(id)?.element;
+  if (!win) return;
   mount(win, ctx);
 }
+
 export function mount(winEl, ctx) {
   const container = winEl.querySelector('.content');
   container.style.display = 'flex';
   container.style.flexDirection = 'column';
-  container.style.gap = '4px';
+  container.style.gap = '6px';
+
+  const controls = document.createElement('div');
+  controls.style.display = 'flex';
+  controls.style.gap = '6px';
 
   const startBtn = document.createElement('button');
   startBtn.textContent = 'Start Recording';
@@ -18,36 +25,116 @@ export function mount(winEl, ctx) {
   stopBtn.textContent = 'Stop Recording';
   stopBtn.disabled = true;
   const playBtn = document.createElement('button');
-  playBtn.textContent = 'Play Recording';
+  playBtn.textContent = 'Play';
   playBtn.disabled = true;
-  const downloadBtn = document.createElement('button');
-  downloadBtn.textContent = 'Download Recording';
-  downloadBtn.disabled = true;
+  const saveBtn = document.createElement('button');
+  saveBtn.textContent = 'Save';
+  saveBtn.disabled = true;
 
-  container.append(startBtn, stopBtn, playBtn, downloadBtn);
+  controls.append(startBtn, stopBtn, playBtn, saveBtn);
 
-  let mediaRecorder;
+  const status = document.createElement('div');
+  status.textContent = 'Ready to record.';
+  status.style.fontSize = '12px';
+  status.style.opacity = '0.8';
+
+  const preview = document.createElement('div');
+  preview.style.display = 'flex';
+  preview.style.alignItems = 'center';
+  preview.style.justifyContent = 'center';
+  preview.style.minHeight = '80px';
+  preview.style.border = '1px solid var(--window-border-dark)';
+  preview.style.padding = '6px';
+
+  container.append(controls, status, preview);
+
+  let mediaRecorder = null;
+  let stream = null;
   let chunks = [];
   let blobUrl = null;
+  let audioEl = null;
+  let cleanupAudio = null;
+
+  function resetPreview() {
+    if (cleanupAudio) {
+      cleanupAudio();
+      cleanupAudio = null;
+    }
+    if (audioEl) {
+      try {
+        audioEl.pause();
+      } catch (err) {
+        /* ignore */
+      }
+      audioEl.remove();
+      audioEl = null;
+    }
+    if (blobUrl) {
+      URL.revokeObjectURL(blobUrl);
+      blobUrl = null;
+    }
+  }
+
+  function updateStatus(text) {
+    status.textContent = text;
+  }
+
+  function stopStream() {
+    if (!stream) return;
+    stream.getTracks().forEach((track) => track.stop());
+    stream = null;
+  }
 
   startBtn.addEventListener('click', async () => {
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      updateStatus('Requesting microphone…');
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (err) {
+      console.error('Microphone access denied', err);
+      updateStatus('Microphone access denied. Please allow permission and try again.');
+      return;
+    }
+
+    try {
       mediaRecorder = new MediaRecorder(stream);
+    } catch (err) {
+      console.error('MediaRecorder init failed', err);
+      updateStatus('Recording is not supported in this browser.');
+      stopStream();
+      return;
+    }
+
+    chunks = [];
+    mediaRecorder.addEventListener('dataavailable', (e) => {
+      if (e.data && e.data.size > 0) chunks.push(e.data);
+    });
+    mediaRecorder.addEventListener('stop', () => {
+      const blob = new Blob(chunks, { type: 'audio/webm' });
+      resetPreview();
+      blobUrl = URL.createObjectURL(blob);
+      audioEl = document.createElement('audio');
+      audioEl.controls = true;
+      audioEl.src = blobUrl;
+      cleanupAudio = ctx.globals.addAudioElement?.(audioEl) || null;
+      preview.innerHTML = '';
+      preview.append(audioEl);
+      playBtn.disabled = false;
+      saveBtn.disabled = false;
+      updateStatus('Recording ready to play or save.');
+      stopStream();
+    });
+
+    try {
       mediaRecorder.start();
+      updateStatus('Recording…');
       startBtn.disabled = true;
       stopBtn.disabled = false;
-      chunks = [];
-      mediaRecorder.addEventListener('dataavailable', e => { chunks.push(e.data); });
-      mediaRecorder.addEventListener('stop', () => {
-        const blob = new Blob(chunks, { type: 'audio/webm' });
-        if (blobUrl) URL.revokeObjectURL(blobUrl);
-        blobUrl = URL.createObjectURL(blob);
-        playBtn.disabled = false;
-        downloadBtn.disabled = false;
-      });
+      playBtn.disabled = true;
+      saveBtn.disabled = true;
     } catch (err) {
-      alert('Failed to access microphone: ' + err);
+      console.error('Recording failed to start', err);
+      updateStatus('Unable to start recording.');
+      stopStream();
     }
   });
 
@@ -60,22 +147,27 @@ export function mount(winEl, ctx) {
   });
 
   playBtn.addEventListener('click', () => {
-    if (blobUrl) {
-      const audio = document.createElement('audio');
-      audio.controls = true;
-      audio.src = blobUrl;
-      ctx.globals.addAudioElement?.(audio);
-      audio.play();
-      ctx.windowManager.createWindow('recording', 'Recording', audio);
-    }
+    if (!audioEl) return;
+    audioEl.play().catch((err) => {
+      console.warn('Playback failed', err);
+    });
   });
 
-  downloadBtn.addEventListener('click', () => {
-    if (blobUrl) {
-      const a = document.createElement('a');
-      a.href = blobUrl;
-      a.download = 'recording.webm';
-      a.click();
-    }
+  saveBtn.addEventListener('click', () => {
+    if (!blobUrl) return;
+    const a = document.createElement('a');
+    a.href = blobUrl;
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    a.download = `recording-${timestamp}.webm`;
+    a.click();
   });
+
+  const cleanup = () => {
+    resetPreview();
+    stopStream();
+    if (mediaRecorder && mediaRecorder.state !== 'inactive') {
+      mediaRecorder.stop();
+    }
+  };
+  winEl.addEventListener('window-closed', cleanup, { once: true });
 }

--- a/style.css
+++ b/style.css
@@ -1078,6 +1078,139 @@ body {
   min-width: 120px;
 }
 
+/* Gallery app */
+.gallery {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.gallery-toolbar {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+
+.gallery-grid {
+  flex: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-content: flex-start;
+  overflow: auto;
+  padding: 4px;
+  border-top: 1px solid var(--window-border-dark);
+}
+
+.gallery-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  width: 120px;
+  padding: 6px;
+  border: 1px solid var(--window-border-dark);
+  background: var(--window-bg);
+  cursor: pointer;
+  text-align: center;
+}
+
+.gallery-card:hover {
+  background: var(--selection-bg);
+  color: #ffffff;
+}
+
+.gallery-thumb {
+  width: 100%;
+  height: 90px;
+  border: 1px dashed var(--window-border-dark);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-size: cover;
+  background-position: center;
+  font-size: 12px;
+  color: inherit;
+}
+
+.gallery-label {
+  font-size: 12px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  width: 100%;
+}
+
+.gallery-empty {
+  font-size: 12px;
+  opacity: 0.7;
+}
+
+.gallery-viewer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  background: var(--window-bg);
+}
+
+.gallery-viewer img {
+  max-width: 100%;
+  max-height: 100%;
+}
+
+/* Media player */
+.media-player {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.media-player-toolbar {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+
+.media-player-stage {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--window-bg);
+  border: 1px solid var(--window-border-dark);
+  margin-bottom: 6px;
+  padding: 4px;
+}
+
+.media-player-stage video,
+.media-player-stage audio {
+  max-width: 100%;
+  max-height: 100%;
+}
+
+.media-player-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.media-player-controls button {
+  font-size: 12px;
+  padding: 2px 8px;
+}
+
+.media-player-controls input[type='range'] {
+  flex: 1;
+}
+
+.media-player-status {
+  font-size: 12px;
+  opacity: 0.7;
+  margin-top: 2px;
+}
+
 /* New two-pane file manager */
 .file-manager-body {
   flex: 1;


### PR DESCRIPTION
## Summary
- wire File Manager launches to route text, media, and image files into the appropriate editors
- rebuild Gallery with thumbnail generation, multi-import, and dedicated viewer windows
- overhaul Media Player controls and Recorder UI with playback, seeking, and permission handling improvements
- add styling for the new gallery and media player layouts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ce53ca865083308a8304b4cb7dc921